### PR TITLE
Add code review schedule to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ Currently, we aim to review pull requests at the following times:
 - Thursday afternoons
 - Friday mornings
   
-All times are in Central European (Summer) Time and are meant for orientation, but because of illness or holidays can't be guaranteed.
+All times are in Central European (Summer) Time and are meant for orientation. Note that we may sometimes not be able to perform reviews in these time slots due to illness, holidays, etc.
 
 ## License
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,17 @@ or a `hotfix` branch (for bug fixes) with `mvn gitflow:hotfix-start`.
     - If your contribution is new functionality, create it against `hexatomic:develop`.
     - If your contribution is a bug fix, create it against `hexatomic:master`.
 
+### Code review schedules
+
+We have regular time slots when the maintainers perform code reviews.
+Currently, we try to review pull requests at the following times:
+- Wednesday mornings
+- Thursday mornings
+- Thursday afternoons
+- Friday mornings
+  
+All times are in Central European (Summer) Time and are meant for orientation, but because of illness or holidays can't be guaranteed.
+
 ## License
 
 By contributing code to Hexatomic, you agree that your contributions will be licensed under its [Apache License, Version 2.0](LICENSE).  

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,8 @@ or a `hotfix` branch (for bug fixes) with `mvn gitflow:hotfix-start`.
 
 ### Code review schedules
 
-We have regular time slots when the maintainers perform code reviews.
+We perform reviews of all changes to Hexatomic, be they in code, documentation, configuration, etc.
+We have therefore set up regular time slots, in which maintainers perform (code) reviews.
 Currently, we try to review pull requests at the following times:
 - Wednesday mornings
 - Thursday mornings

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ or a `hotfix` branch (for bug fixes) with `mvn gitflow:hotfix-start`.
 
 We perform reviews of all changes to Hexatomic, be they in code, documentation, configuration, etc.
 We have therefore set up regular time slots, in which maintainers perform (code) reviews.
-Currently, we try to review pull requests at the following times:
+Currently, we aim to review pull requests at the following times:
 - Wednesday mornings
 - Thursday mornings
 - Thursday afternoons


### PR DESCRIPTION
As discussed and documented in https://github.com/hexatomic/hexatomic.github.io/pull/12, we should publish our current code review schedules in the CONTRIBUTING.md file.