### PR TITLE
Fix notification for nodes that have been created before the editor attached itself

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Update views via notification even if the object that changed was created before the view.
+
 ## [0.3.1] - 2019-12-16
 
 ### Fixed

--- a/bundles/org.corpus_tools.hexatomic.core/src/main/java/org/corpus_tools/hexatomic/core/ProjectManager.java
+++ b/bundles/org.corpus_tools.hexatomic.core/src/main/java/org/corpus_tools/hexatomic/core/ProjectManager.java
@@ -158,7 +158,7 @@ public class ProjectManager {
   }
 
   /**
-   * We can't add listeners to existing objects in the corpus grap, so iterate over the internal
+   * We can't add listeners to existing objects in the corpus graph, so iterate over the internal
    * list of all registered listeners and notify them.
    *
    */

--- a/releng/org.corpus_tools.hexatomic.target/org.corpus_tools.hexatomic.target.target
+++ b/releng/org.corpus_tools.hexatomic.target/org.corpus_tools.hexatomic.target.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="Hexatomic Target Platform Definition" sequenceNumber="1575631785">
+<target name="Hexatomic Target Platform Definition" sequenceNumber="1580149377">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="true" type="InstallableUnit">
       <unit id="org.eclipse.platform.sdk" version="4.12.0.I20190605-1800"/>
@@ -27,8 +27,8 @@
       <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20190602212107/repository/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="true" type="InstallableUnit">
-      <unit id="org.corpus-tools.salt-api" version="3.3.8"/>
-      <unit id="org.corpus-tools.salt-extensions" version="3.3.8"/>
+      <unit id="org.corpus-tools.salt-api" version="3.3.9"/>
+      <unit id="org.corpus-tools.salt-extensions" version="3.3.9"/>
       <repository location="https://korpling.github.io/salt/p2/salt-3.3/"/>
     </location>
   </locations>

--- a/releng/org.corpus_tools.hexatomic.target/org.corpus_tools.hexatomic.target.tpd
+++ b/releng/org.corpus_tools.hexatomic.target/org.corpus_tools.hexatomic.target.tpd
@@ -28,7 +28,7 @@ location 'https://download.eclipse.org/tools/orbit/downloads/drops/R201906022121
 }
 
 location 'https://korpling.github.io/salt/p2/salt-3.3/' {
-	org.corpus-tools.salt-api [3.3.8,3.4.0)
-	org.corpus-tools.salt-extensions [3.3.8,3.4.0)
+	org.corpus-tools.salt-api [3.3.9,3.4.0)
+	org.corpus-tools.salt-extensions [3.3.9,3.4.0)
 	
 }


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help. -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [X] The *Unreleased* section in CHANGELOG.md has been amended to reflect the changes in this PR
- [X] Build (`mvn verify`) was run locally and any changes were pushed
- [X] The pull request is against the correct branch (`master` for bug fixes, `develop` for new functionality)


## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

If some (yet non-existing) editor deletes an existing object, the view won't update.
This is caused because only objects created after the view is created have the correct listener list.

Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
This PR avoids the bug by keeping an internal list and proxy the notifications to the listeners in this internal list.
It also updates to Salt 3.3.9, which includes a bug fix where nodes can't be removed from graphs with notifications. 
## Does this introduce a breaking change?

- [X] Yes
- [ ] No
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

Kind of, because we are not directly attaching the listeners to Salt anymore.

## Does this introduce new dependencies?

- [ ] Yes
- [X] No

If this introduces new dependencies:

- [ ] [Dependencies and citation templates](https://github.com/hexatomic/hexatomic/tree/develop/releng/templates) have been updated where necessary

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

# Checklist for maintainers

## Releases

- [ ] Do **NOT** push the green merge button on GitHub.  
Follow the latest version of the [developer/maintainer docs](https://hexatomic.github.io/hexatomic/dev/) for making releases.
- [ ] License and citation information for dependencies are complete (each dependency has a folder in `/THIRD-PARTY/`).