### PR TITLE
Use SWTKeyboardStrategy consistently in all UI integration tests

### DIFF
--- a/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestCorpusStructure.java
+++ b/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestCorpusStructure.java
@@ -31,6 +31,8 @@ class TestCorpusStructure {
 
   @BeforeEach
   void setup() {
+    org.eclipse.swtbot.swt.finder.utils.SWTBotPreferences.KEYBOARD_STRATEGY =
+        "org.eclipse.swtbot.swt.finder.keyboard.SWTKeyboardStrategy";
 
     IEclipseContext ctx = ContextHelper.getEclipseContext();
 

--- a/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestCorpusStructure.java
+++ b/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestCorpusStructure.java
@@ -73,13 +73,14 @@ class TestCorpusStructure {
     bot.tree().getTreeItem("corpus_graph_1").getNode("corpus_1").getNode("document_1").select();
     bot.tree().getTreeItem("corpus_graph_1").getNode("corpus_1").getNode("document_1")
         .doubleClick();
-    bot.text("document_1").setText("abc").pressShortcut(Keystrokes.LF);
+    bot.text("document_1").typeText("abc\n");
+
 
     bot.tree().expandNode("corpus_graph_1").expandNode("corpus_1").expandNode("document_2");
     bot.tree().getTreeItem("corpus_graph_1").getNode("corpus_1").getNode("document_2").select();
     bot.tree().getTreeItem("corpus_graph_1").getNode("corpus_1").getNode("document_2")
         .doubleClick();
-    bot.text("document_2").setText("def").pressShortcut(Keystrokes.LF);
+    bot.text("document_2").typeText("def\n");
   }
 
   @Test

--- a/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestCorpusStructure.java
+++ b/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestCorpusStructure.java
@@ -73,14 +73,13 @@ class TestCorpusStructure {
     bot.tree().getTreeItem("corpus_graph_1").getNode("corpus_1").getNode("document_1").select();
     bot.tree().getTreeItem("corpus_graph_1").getNode("corpus_1").getNode("document_1")
         .doubleClick();
-    bot.text("document_1").typeText("abc\n");
-
+    bot.text("document_1").setText("abc").pressShortcut(Keystrokes.LF);
 
     bot.tree().expandNode("corpus_graph_1").expandNode("corpus_1").expandNode("document_2");
     bot.tree().getTreeItem("corpus_graph_1").getNode("corpus_1").getNode("document_2").select();
     bot.tree().getTreeItem("corpus_graph_1").getNode("corpus_1").getNode("document_2")
         .doubleClick();
-    bot.text("document_2").typeText("def\n");
+    bot.text("document_2").setText("def").pressShortcut(Keystrokes.LF);
   }
 
   @Test

--- a/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestGraphEditor.java
+++ b/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestGraphEditor.java
@@ -42,6 +42,9 @@ class TestGraphEditor {
 
   @BeforeEach
   void setup() {
+    org.eclipse.swtbot.swt.finder.utils.SWTBotPreferences.KEYBOARD_STRATEGY =
+        "org.eclipse.swtbot.swt.finder.keyboard.SWTKeyboardStrategy";
+    
     IEclipseContext ctx = ContextHelper.getEclipseContext();
 
     ctx.set(ErrorService.class, errorService);


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help. -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] The *Unreleased* section in CHANGELOG.md has been amended to reflect the changes in this PR
- [X] Build (`mvn verify`) was run locally and any changes were pushed
- [X] The pull request is against the correct branch (`master` for bug fixes, `develop` for new functionality)


## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [X] Refactoring (no functional changes, no API changes)
- [X] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: fixes #159 

The tests in the corpus structure editor where particular time sensitive, because renaming the example documents did not always work.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

We are now using SWTKeyboardStrategy in the existing tests, which should give a more consistent behavior with `pressShortcut()`.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Does this introduce new dependencies?

- [ ] Yes
- [X] No

If this introduces new dependencies:

- [ ] [Dependencies and citation templates](https://github.com/hexatomic/hexatomic/tree/develop/releng/templates) have been updated where necessary

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

# Checklist for maintainers

## Releases

- [ ] Do **NOT** push the green merge button on GitHub.  
Follow the latest version of the [developer/maintainer docs](https://hexatomic.github.io/hexatomic/dev/) for making releases.
- [ ] License and citation information for dependencies are complete (each dependency has a folder in `/THIRD-PARTY/`).