### PR TITLE
Fix Java 11 issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,11 @@ os: linux
 jobs:
   include:
     - language: java
-
-      jdk: 
-      - openjdk8
-      - openjdk11
+      jdk: openjdk11
+      name: OpenJDK 11
+    - language: java
+      jdk: openjdk8
+      name: OpenJDK 8
 
       # enable a window manager to execute UI integration tests
       addons:
@@ -51,6 +52,7 @@ jobs:
           tag_name: $TRAVIS_TAG
 
     - language: rust
+      name: Documentation
      
       cache:
         - cargo

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,9 @@ jobs:
   include:
     - language: java
 
-      matrix:
-	  include:
-	    - name: OpenJDK 8
-	      jdk: openjdk11
-	    - name: OpenJDK 11
-	      jdk: openjdk11
+      jdk: 
+      - openjdk8
+      - openjdk11
 
       # enable a window manager to execute UI integration tests
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,23 @@
 os: linux
+# enable a window manager to execute UI integration tests
+addons:
+  apt:
+    packages:
+      - metacity
+services:
+  - xvfb
+  - metacity
+
+before_install:
+  - export DISPLAY=:99.0
+  - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1920x1080x16"
+  - sleep 5
+  - metacity --sm-disable --replace 2> metacity.err &
+
+script:
+  - mvn integration-test
+  - mvn verify -B
+
 jobs:
   include:
     - language: java
@@ -8,43 +27,18 @@ jobs:
       jdk: openjdk8
       name: OpenJDK 8
 
-      # enable a window manager to execute UI integration tests
-      addons:
-        apt:
-          packages:
-          - metacity
-      services:
-        - xvfb
-        - metacity
-
-      # Enforce Maven version to fix regression with version 3.6.2, used by Travis as of 2019-12-11
-      # Cf. https://issues.apache.org/jira/browse/MNG-6765
-      before_install:
-        - wget https://archive.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.zip
-        - unzip -qq apache-maven-3.6.3-bin.zip
-        - export M2_HOME=$PWD/apache-maven-3.6.3
-        - export PATH=$M2_HOME/bin:$PATH
-        - export DISPLAY=:99.0
-        - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1920x1080x16"
-        - sleep 5
-        - metacity --sm-disable --replace 2> metacity.err &
-      
-      script:
-        - mvn integration-test
-        - mvn verify -B
-      
       before_deploy:
-         - mvn clean install && mvn -f ./features/org.corpus_tools.hexatomic/pom.xml cff:create && mvn clean verify
-      
+        - mvn clean install && mvn -f ./features/org.corpus_tools.hexatomic/pom.xml cff:create && mvn clean verify
+
       deploy:
         - provider: releases
           api_key:
-             secure: $GITHUB_TOKEN
+            secure: $GITHUB_TOKEN
           on:
-             repo: hexatomic/hexatomic
-             branch: master
-             tags: true
-             condition: $TRAVIS_OS_NAME = linux
+            repo: hexatomic/hexatomic
+            branch: master
+            tags: true
+            condition: $TRAVIS_OS_NAME = linux
           skip_cleanup: true
           draft: true
           file_glob: true
@@ -53,7 +47,7 @@ jobs:
 
     - language: rust
       name: Documentation
-     
+
       cache:
         - cargo
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ jobs:
   include:
     - language: java
 
-      jdk: openjdk8
+      jdk: 
+      - openjdk8
+      - openjdk11
 
       # enable a window manager to execute UI integration tests
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,7 @@ before_install:
   - metacity --sm-disable --replace 2> metacity.err &
 
 script:
-  - mvn integration-test
-  - mvn verify -B
+  - mvn -B verify
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,12 @@ jobs:
   include:
     - language: java
 
-      jdk: 
-      - openjdk8
-      - openjdk11
+      matrix:
+	  include:
+	    - name: OpenJDK 8
+	      jdk: openjdk11
+	    - name: OpenJDK 11
+	      jdk: openjdk11
 
       # enable a window manager to execute UI integration tests
       addons:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Update views via notification even if the object that changed was created before the view.
+- Allow to run Hexatomic on Java 11 platforms
 
 ## [0.3.1] - 2019-12-16
 

--- a/bundles/org.corpus_tools.hexatomic.core/META-INF/MANIFEST.MF
+++ b/bundles/org.corpus_tools.hexatomic.core/META-INF/MANIFEST.MF
@@ -20,7 +20,8 @@ Require-Bundle: javax.inject;bundle-version="0.0.0",
  ch.qos.logback.classic;bundle-version="1.1.2",
  ch.qos.logback.core;bundle-version="1.1.2",
  org.slf4j.api;bundle-version="1.7.10",
- org.corpus-tools.salt-api
+ org.corpus-tools.salt-api,
+ javax.annotation;bundle-version="1.2.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Automatic-Module-Name: org.corpus_tools.hexatomic.core
 Export-Package: org.corpus_tools.hexatomic.core,

--- a/bundles/org.corpus_tools.hexatomic.corpusedit/META-INF/MANIFEST.MF
+++ b/bundles/org.corpus_tools.hexatomic.corpusedit/META-INF/MANIFEST.MF
@@ -16,7 +16,8 @@ Require-Bundle: javax.inject,
  org.slf4j.api,
  org.eclipse.emf.common;bundle-version="2.16.0",
  org.eclipse.e4.ui.workbench;bundle-version="1.10.0",
- org.corpus-tools.salt-extensions
+ org.corpus-tools.salt-extensions,
+ javax.annotation;bundle-version="1.2.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Automatic-Module-Name: org.corpus_tools.hexatomic.corpusedit
 Bundle-ClassPath: .

--- a/bundles/org.corpus_tools.hexatomic.graph/META-INF/MANIFEST.MF
+++ b/bundles/org.corpus_tools.hexatomic.graph/META-INF/MANIFEST.MF
@@ -22,7 +22,8 @@ Require-Bundle: javax.inject,
  org.corpus-tools.salt-extensions;bundle-version="3.3.8",
  org.hamcrest.library;bundle-version="1.3.0",
  org.antlr.runtime;bundle-version="4.7.1",
- org.eclipse.e4.core.services
+ org.eclipse.e4.core.services,
+ javax.annotation;bundle-version="1.2.0"
 Automatic-Module-Name: org.corpus_tools.hexatomic.edit.graph
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.corpus_tools.hexatomic.console,

--- a/bundles/org.corpus_tools.hexatomic.grid/META-INF/MANIFEST.MF
+++ b/bundles/org.corpus_tools.hexatomic.grid/META-INF/MANIFEST.MF
@@ -13,7 +13,8 @@ Require-Bundle: javax.inject,
  org.eclipse.nebula.widgets.nattable.core,
  org.eclipse.e4.ui.workbench,
  org.eclipse.e4.ui.services,
- org.eclipse.e4.core.di.annotations
+ org.eclipse.e4.core.di.annotations,
+ javax.annotation;bundle-version="1.2.0"
 Automatic-Module-Name: org.corpus_tools.hexatomic.grid
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.corpus_tools.hexatomic.grid.style

--- a/bundles/org.corpus_tools.hexatomic.textviewer/META-INF/MANIFEST.MF
+++ b/bundles/org.corpus_tools.hexatomic.textviewer/META-INF/MANIFEST.MF
@@ -15,7 +15,8 @@ Require-Bundle: javax.inject,
  org.corpus_tools.hexatomic.core;bundle-version="0.1.0",
  org.slf4j.api,
  org.eclipse.emf.common;bundle-version="2.16.0",
- org.eclipse.e4.core.services
+ org.eclipse.e4.core.services,
+ javax.annotation;bundle-version="1.2.0"
 Automatic-Module-Name: org.corpus_tools.hexatomic.textview
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.corpus_tools.hexatomic.textviewer


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help. -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] The *Unreleased* section in CHANGELOG.md has been amended to reflect the changes in this PR
- [x] Build (`mvn verify`) was run locally and any changes were pushed
- [x] The pull request is against the correct branch (`master` for bug fixes, `develop` for new functionality)


## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Until Eclipse is not bundling its own JVM, we should make sure to support as many JVMs as possible. Currently, Hexatomic neither runs nor is tested automatically on Java 11 (only on Java 8).

Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Added an additional Java 11 configuration to Travis CI to make sure we don't introduce bugs on this platform
- Explicitly declare javax.annotation as dependency in the manifest file
- The workaround for <https://issues.apache.org/jira/browse/MNG-6765> has been removed from the Travis configuration, since Maven 3.6.3 is now used automatically. This enhances the readability of the configuration especially with multiple jobs present. 
- Reducing CI execution times by only calling "mvn verify", which already includes the integration tests.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Does this introduce new dependencies?

- [ ] Yes
- [x] No

If this introduces new dependencies:

- [ ] [Dependencies and citation templates](https://github.com/hexatomic/hexatomic/tree/develop/releng/templates) have been updated where necessary

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

# Checklist for maintainers

## Releases

- [ ] Do **NOT** push the green merge button on GitHub.  
Follow the latest version of the [developer/maintainer docs](https://hexatomic.github.io/hexatomic/dev/) for making releases.
- [ ] License and citation information for dependencies are complete (each dependency has a folder in `/THIRD-PARTY/`).