### PR TITLE
Calculate graph segments and the tokens belonging to them in background

### DIFF
--- a/bundles/org.corpus_tools.hexatomic.graph/src/main/java/org/corpus_tools/hexatomic/graph/GraphEditor.java
+++ b/bundles/org.corpus_tools.hexatomic.graph/src/main/java/org/corpus_tools/hexatomic/graph/GraphEditor.java
@@ -92,7 +92,6 @@ import org.eclipse.swt.events.MouseListener;
 import org.eclipse.swt.events.MouseWheelListener;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.events.SelectionListener;
-import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
@@ -149,8 +148,6 @@ public class GraphEditor {
 
   @Inject
   ErrorService errors;
-
-  private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(GraphEditor.class);
 
   @Inject
   private IEventBroker events;
@@ -453,8 +450,6 @@ public class GraphEditor {
         for (TableItem item : textRangeTable.getSelection()) {
           oldSelectedRanges.add((Range<Long>) item.getData("range"));
         }
-        // All ranges will be re-calculated in the background job.
-        textRangeTable.removeAll();
       } else {
 
         // The ranges that will be selected will be the same as the current ones
@@ -478,6 +473,7 @@ public class GraphEditor {
               calculateSegments(graph, currentFilter);
 
           sync.syncExec(() -> {
+            textRangeTable.removeAll();
             for (Map.Entry<STextualDS, Range<Long>> e : segments.entries()) {
               TableItem item = new TableItem(textRangeTable, SWT.NONE);
 

--- a/docs/user/src/usage/graph-editor/README.md
+++ b/docs/user/src/usage/graph-editor/README.md
@@ -8,6 +8,8 @@ It provides a general visualization that displays all possible types of annotati
 ## Filters
 
 On the right-hand side of the interface, you can select which segment of the current document to show in the [graph view](#graph-view).
+For large graphs, it can take some time until its layout is calculated.
+The checkbox next to the segment indicates if this calculation is finished.
 You can select more than one segment to display, by holding the <kbd>Ctrl</kbd> key while clicking on additional segments.
 You can also show a whole range of segments by holding the <kbd>Shift</kbd> key and clicking on the last segment of the range you want to select.
 

--- a/features/org.corpus_tools.hexatomic/feature.xml
+++ b/features/org.corpus_tools.hexatomic/feature.xml
@@ -83,4 +83,11 @@
          version="0.0.0"
          unpack="false"/>
 
+   <plugin
+         id="org.corpus_tools.hexatomic.graph"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
 </feature>


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help. -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] The *Unreleased* section in CHANGELOG.md has been amended to reflect the changes in this PR
- [X] Build (`mvn verify`) was run locally and any changes were pushed
- [X] The pull request is against the correct branch (`master` for bug fixes, `develop` for new functionality)


## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [X] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The current implementation of the segment calculation is executed in the UI thread when the filter has changed. Also, the tokens belonging to the segment are calculated in the UI thread whenever the selected segment changes 

Issue Number: this fixes #131  for me. Probably because before the UI thread was blocked for quite some time, not processing any more user interactions.


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Calculation which segments exist is done in a background job
- Calculating which tokens belong to a segment is done in a background job
- When the graph finished its layout after it a new segment was selected, the view automatically adjusts to show the first token and the complete height of the graph
- The checkboxes in the segment list now actually have a function: when a segment is selected the checkbox only becomes activated after all calculations are done.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Does this introduce new dependencies?

- [ ] Yes
- [X] No

If this introduces new dependencies:

- [ ] [Dependencies and citation templates](https://github.com/hexatomic/hexatomic/tree/develop/releng/templates) have been updated where necessary

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

# Checklist for maintainers

## Releases

- [ ] Do **NOT** push the green merge button on GitHub.  
Follow the latest version of the [developer/maintainer docs](https://hexatomic.github.io/hexatomic/dev/) for making releases.
- [ ] License and citation information for dependencies are complete (each dependency has a folder in `/THIRD-PARTY/`).