### PR TITLE
Fix typo

### DIFF
--- a/docs/dev/src/development/automated-tests/README.md
+++ b/docs/dev/src/development/automated-tests/README.md
@@ -19,7 +19,7 @@ The special bundle `org.corpus_tools.hexatomic.it.tests` is used for [integratio
 We are using the [Tycho Surefire Plugin](https://www.eclipse.org/tycho/sitedocs/tycho-surefire/tycho-surefire-plugin/) 
 to execute the tests.
 Tests are executed when building the project with `mvn install`.
-To specifically run the tests and not install the artifacts, use `mvn integration-tests` instead.
+To specifically run the tests and not install the artifacts, use `mvn integration-test` instead.
 Unlike unit tests, `mvn test` will not work for integration tests, as the Tycho Surefire Plugin requires
 the bundles to be packaged, which happens in Maven's `package` phase, which comes after `test` and before `integration-test`.
 


### PR DESCRIPTION
Fixes a typo in the dev docs (automated-tests/README.md).