### PR TITLE
Use currently selected text as base for tokenization

### DIFF
--- a/bundles/org.corpus_tools.hexatomic.graph/src/main/java/org/corpus_tools/hexatomic/console/ConsoleController.java
+++ b/bundles/org.corpus_tools.hexatomic.graph/src/main/java/org/corpus_tools/hexatomic/console/ConsoleController.java
@@ -33,6 +33,7 @@ import org.antlr.v4.runtime.tree.ParseTreeWalker;
 import org.corpus_tools.hexatomic.console.ConsoleCommandParser.StartContext;
 import org.corpus_tools.hexatomic.console.internal.SyntaxListener;
 import org.corpus_tools.salt.common.SDocumentGraph;
+import org.corpus_tools.salt.common.STextualDS;
 
 /**
  * Executes commands on an annotation graph.
@@ -45,6 +46,7 @@ public class ConsoleController {
   private static final int MAX_HISTORY_LENGTH = 1000;
 
   private SDocumentGraph graph;
+  private STextualDS selectedText;
 
   private final LinkedList<String> commandHistory = new LinkedList<>();
   private ListIterator<String> itCommandHistory;
@@ -97,7 +99,7 @@ public class ConsoleController {
     if (errorListener.errors.isEmpty()) {
       // Collect the relevant elements of the AST and execute the command
       ParseTreeWalker walker = new ParseTreeWalker();
-      SyntaxListener listener = new SyntaxListener(graph);
+      SyntaxListener listener = new SyntaxListener(graph, getSelectedText());
       walker.walk(listener, startCtx);
       output.addAll(listener.getOutputLines());
     } else {
@@ -117,13 +119,33 @@ public class ConsoleController {
   public ListIterator<String> getCommandHistoryIterator() {
     return itCommandHistory;
   }
-  
+
   public SDocumentGraph getGraph() {
     return graph;
   }
-  
+
   public void setGraph(SDocumentGraph graph) {
     this.graph = graph;
+  }
+
+  public void setSelectedText(STextualDS selectedText) {
+    this.selectedText = selectedText;
+  }
+
+  private STextualDS getSelectedText() {
+    if (this.selectedText == null) {
+      // Find the first data source of the current graph
+      if (this.graph != null) {
+        List<STextualDS> texts = this.graph.getTextualDSs();
+        if (texts != null && !texts.isEmpty()) {
+          return texts.get(0);
+        }
+      }
+    } else {
+      return this.selectedText;
+    }
+
+    return null;
   }
 
   private final class ErrorListener extends BaseErrorListener {

--- a/bundles/org.corpus_tools.hexatomic.graph/src/main/java/org/corpus_tools/hexatomic/console/ConsoleView.java
+++ b/bundles/org.corpus_tools.hexatomic.graph/src/main/java/org/corpus_tools/hexatomic/console/ConsoleView.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.Optional;
 import org.corpus_tools.salt.common.SDocumentGraph;
+import org.corpus_tools.salt.common.STextualDS;
 import org.eclipse.e4.ui.di.UISynchronize;
 import org.eclipse.jface.resource.JFaceResources;
 import org.eclipse.jface.text.BadLocationException;
@@ -96,6 +97,15 @@ public class ConsoleView implements Runnable, IDocumentListener, VerifyListener 
    */
   public void setGraph(SDocumentGraph graph) {
     this.controller.setGraph(graph);
+  }
+
+  /**
+   * Sets a textual data source that has been selected.
+   * 
+   * @param selectedText The selected data source.
+   */
+  public void setSelectedText(STextualDS selectedText) {
+    this.controller.setSelectedText(selectedText);
   }
 
   /**

--- a/bundles/org.corpus_tools.hexatomic.graph/src/main/java/org/corpus_tools/hexatomic/console/internal/SyntaxListener.java
+++ b/bundles/org.corpus_tools.hexatomic.graph/src/main/java/org/corpus_tools/hexatomic/console/internal/SyntaxListener.java
@@ -74,6 +74,7 @@ import org.corpus_tools.salt.util.DataSourceSequence;
 public class SyntaxListener extends ConsoleCommandBaseListener {
 
   private final SDocumentGraph graph;
+  private final STextualDS selectedText;
   private final Set<SStructuredNode> referencedNodes = new LinkedHashSet<>();
   private final Set<SRelation<?, ?>> referencedEdges = new LinkedHashSet<>();
   private final Set<SAnnotation> attributes = new LinkedHashSet<>();
@@ -84,9 +85,11 @@ public class SyntaxListener extends ConsoleCommandBaseListener {
    * Creates a new ANTLR listener.
    * 
    * @param graph The document graph to manipulate.
+   * @param selectedText The currently selected textual data source.
    */
-  public SyntaxListener(SDocumentGraph graph) {
+  public SyntaxListener(SDocumentGraph graph, STextualDS selectedText) {
     this.graph = graph;
+    this.selectedText = selectedText;
   }
 
   public List<String> getOutputLines() {
@@ -340,9 +343,11 @@ public class SyntaxListener extends ConsoleCommandBaseListener {
 
     } else {
       // append to the first existing data source
-      ds = graph.getTextualDSs().iterator().next();
-      sb = new StringBuilder(ds.getText());
-      if (sb.length() > 0) {
+      ds = this.selectedText;
+      String originalText = ds.getText();
+      sb = new StringBuilder(originalText);
+      if (originalText.length() > 0 && originalText.charAt(originalText.length() - 1) != ' ') {
+        // Add a space to separate the new tokens from the original text
         sb.append(' ');
       }
     }

--- a/bundles/org.corpus_tools.hexatomic.graph/src/main/java/org/corpus_tools/hexatomic/graph/GraphEditor.java
+++ b/bundles/org.corpus_tools.hexatomic.graph/src/main/java/org/corpus_tools/hexatomic/graph/GraphEditor.java
@@ -524,6 +524,13 @@ public class GraphEditor {
 
         sync.asyncExec(() -> {
 
+          // make sure the console view knows about the currently selected text
+          if (newSelectedSegments.isEmpty()) {
+            consoleView.setSelectedText(null);
+          } else {
+            consoleView.setSelectedText(newSelectedSegments.get(0).text);
+          }
+
           // update the status check for each item
           for (int idx = 0; idx < textRangeTable.getItemCount(); idx++) {
             textRangeTable.getItem(idx).setChecked(textRangeTable.isSelected(idx));

--- a/bundles/org.corpus_tools.hexatomic.graph/src/main/java/org/corpus_tools/hexatomic/graph/GraphEditor.java
+++ b/bundles/org.corpus_tools.hexatomic.graph/src/main/java/org/corpus_tools/hexatomic/graph/GraphEditor.java
@@ -234,6 +234,7 @@ public class GraphEditor {
     textRangeTable.setLinesVisible(true);
     textRangeTable.getHorizontalBar().setEnabled(true);
     textRangeTable.getVerticalBar().setEnabled(true);
+    textRangeTable.setData(ORG_ECLIPSE_SWTBOT_WIDGET_KEY, "graph-editor/text-range");
 
     TableColumn tblclmnFilterBySegment = new TableColumn(textRangeTable, SWT.NONE);
     tblclmnFilterBySegment.setWidth(100);

--- a/tests/org.corpus_tools.hexatomic.graph.tests/src/main/java/org/corpus_tools/hexatomic/console/TestConsoleController.java
+++ b/tests/org.corpus_tools.hexatomic.graph.tests/src/main/java/org/corpus_tools/hexatomic/console/TestConsoleController.java
@@ -266,5 +266,4 @@ class TestConsoleController {
     console.executeCommand("e #n1 > #t2 ns:n:a");
     assertEquals(3, graph.getDominanceRelations().size()); 
   }
-
 }

--- a/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestGraphEditor.java
+++ b/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestGraphEditor.java
@@ -135,13 +135,13 @@ class TestGraphEditor {
 
     // Remember the index of the currently selected segment
     Optional<Integer> firstSelectedRow = Optional.empty();
-    for(int i=0; i < textRangeTable.rowCount(); i++) {
+    for (int i = 0; i < textRangeTable.rowCount(); i++) {
       if (textRangeTable.getTableItem(i).isChecked()) {
         firstSelectedRow = Optional.of(i);
         break;
       }
     }
-    
+
     // We can't use typeText() here, because it would generate upper case characters
     console.insertText(command);
     // Make sure the cursor is at the end of the line
@@ -153,12 +153,12 @@ class TestGraphEditor {
     if (firstSelectedRow.isPresent()) {
       int row = firstSelectedRow.get();
       bot.waitUntil(new DefaultCondition() {
-  
+
         @Override
         public boolean test() throws Exception {
           return textRangeTable.getTableItem(row).isChecked();
         }
-  
+
         @Override
         public String getFailureMessage() {
           return "Second text segment was not checked";
@@ -186,11 +186,11 @@ class TestGraphEditor {
   void testAddPointingRelation() {
 
     openDefaultExample();
-    
+
     // Get a reference to the open graph
     SDocument doc = projectManager.getDocument("salt:/rootCorpus/subCorpus1/doc1").get();
     SDocumentGraph graph = doc.getDocumentGraph();
-    
+
     // Before state: no edges between the two structures
     assertEquals(0, graph.getRelations("salt:/rootCorpus/subCorpus1/doc1#structure3",
         "salt:/rootCorpus/subCorpus1/doc1#structure5").size());
@@ -209,24 +209,24 @@ class TestGraphEditor {
     assertTrue(rels.get(0) instanceof SPointingRelation);
 
   }
-  
+
   /**
-   * Tests if the "t" command adds the new tokens to the currently selected textual datasource.
-   * This is a regression test for https://github.com/hexatomic/hexatomic/issues/139.
+   * Tests if the "t" command adds the new tokens to the currently selected textual datasource. This
+   * is a regression test for https://github.com/hexatomic/hexatomic/issues/139.
    */
   @Test
   @Order(3)
   void testTokenizeSelectedTextualDS() {
-    
+
     openDefaultExample();
-    
+
     // Get a reference to the opened document graph
     SDocument doc = projectManager.getDocument("salt:/rootCorpus/subCorpus1/doc1").get();
     SDocumentGraph graph = doc.getDocumentGraph();
-    
+
     STextualDS firstText = graph.getTextualDSs().get(0);
-    String originalText = firstText.getText();
-    
+    final String originalText = firstText.getText();
+
     // Add an additional data source to the document graph
     STextualDS anotherText = graph.createTextualDS("Another text");
     graph.createToken(anotherText, 0, 7);
@@ -235,27 +235,27 @@ class TestGraphEditor {
     // Select the new text
     SWTBotTable textRangeTable = bot.tableWithId("graph-editor/text-range");
     textRangeTable.select("Another text");
-    
+
     // Wait until the graph has been properly selected
     bot.waitUntil(new DefaultCondition() {
-      
+
       @Override
       public boolean test() throws Exception {
         return textRangeTable.getTableItem("Another text").isChecked();
       }
-      
+
       @Override
       public String getFailureMessage() {
         return "Second text segment was not checked";
       }
     }, 5000);
-    
+
     // Add a new tokenized text to the end
     enterCommand("t has more tokens");
 
     // Check that the right textual data source has been amended
     assertEquals("Another text has more tokens", anotherText.getText());
-    
+
     // Check the original text has not been altered and is displayed correctly
     assertEquals(originalText, firstText.getText());
     assertEquals(originalText, textRangeTable.cell(0, 0));

--- a/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestGraphEditor.java
+++ b/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestGraphEditor.java
@@ -224,6 +224,9 @@ class TestGraphEditor {
     SDocument doc = projectManager.getDocument("salt:/rootCorpus/subCorpus1/doc1").get();
     SDocumentGraph graph = doc.getDocumentGraph();
     
+    STextualDS firstText = graph.getTextualDSs().get(0);
+    String originalText = firstText.getText();
+    
     // Add an additional data source to the document graph
     STextualDS anotherText = graph.createTextualDS("");
     graph.insertTokensAt(anotherText, 0, Arrays.asList("Another", "text"), true);
@@ -250,10 +253,13 @@ class TestGraphEditor {
     // Add a new tokenized text to the end
     enterCommand("t has more tokens");
 
-    
     // Check that the right textual data source has been amended
     assertEquals("Another text has more tokens", anotherText.getText());
     
+    // Check the original text has not been altered and is displayed correctly
+    assertEquals(originalText, firstText.getText());
+    assertEquals(originalText, textRangeTable.cell(0, 0));
+
   }
 
 

--- a/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestGraphEditor.java
+++ b/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestGraphEditor.java
@@ -7,7 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -228,10 +227,10 @@ class TestGraphEditor {
     String originalText = firstText.getText();
     
     // Add an additional data source to the document graph
-    STextualDS anotherText = graph.createTextualDS("");
-    graph.insertTokensAt(anotherText, 0, Arrays.asList("Another", "text"), true);
-    
-    
+    STextualDS anotherText = graph.createTextualDS("Another text");
+    graph.createToken(anotherText, 0, 7);
+    graph.createToken(anotherText, 8, 12);
+
     // Select the new text
     SWTBotTable textRangeTable = bot.tableWithId("graph-editor/text-range");
     textRangeTable.select("Another text");

--- a/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestGraphEditor.java
+++ b/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestGraphEditor.java
@@ -202,7 +202,6 @@ class TestGraphEditor {
     assertFalse(errorService.getLastException().isPresent());
 
     // Check that the edge has been added to the graph
-
     List<?> rels = graph.getRelations("salt:/rootCorpus/subCorpus1/doc1#structure3",
         "salt:/rootCorpus/subCorpus1/doc1#structure5");
     assertEquals(1, rels.size());

--- a/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestGraphEditor.java
+++ b/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestGraphEditor.java
@@ -92,6 +92,7 @@ class TestGraphEditor {
     // Programmatically open the example corpus
     Map<String, String> params = new HashMap<>();
     params.put(CommandParams.LOCATION, exampleProjectUri.toFileString());
+    params.put(CommandParams.FORCE_CLOSE, "true");
     ParameterizedCommand cmd = commandService
         .createCommand("org.corpus_tools.hexatomic.core.command.open_salt_project", params);
     handlerService.executeHandler(cmd);

--- a/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestGridEditor.java
+++ b/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestGridEditor.java
@@ -150,6 +150,7 @@ public class TestGridEditor {
   private void openExample(URI exampleUri) {
     Map<String, String> params = new HashMap<>();
     params.put(CommandParams.LOCATION, exampleUri.toFileString());
+    params.put(CommandParams.FORCE_CLOSE, "true");
     ParameterizedCommand cmd = commandService
         .createCommand("org.corpus_tools.hexatomic.core.command.open_salt_project", params);
     handlerService.executeHandler(cmd);


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help. -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] The *Unreleased* section in CHANGELOG.md has been amended to reflect the changes in this PR
- [X] Build (`mvn verify`) was run locally and any changes were pushed
- [X] The pull request is against the correct branch (`master` for bug fixes, `develop` for new functionality)


## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The `t` command in the console would only tokenize the first text of an annotation graph, regardless which textual data source was referenced by the current selected segment.

Issue Number: fixes #139 


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- When a segment is selected, the new selected data source is propagated to the console
- If no segment is selected, the first text will be used as base for tokenization

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Does this introduce new dependencies?

- [ ] Yes
- [ ] No

If this introduces new dependencies:

- [ ] [Dependencies and citation templates](https://github.com/hexatomic/hexatomic/tree/develop/releng/templates) have been updated where necessary

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

This includes the commit PR #174  because the tests won't run otherwise

---

# Checklist for maintainers

## Releases

- [ ] Do **NOT** push the green merge button on GitHub.  
Follow the latest version of the [developer/maintainer docs](https://hexatomic.github.io/hexatomic/dev/) for making releases.
- [ ] License and citation information for dependencies are complete (each dependency has a folder in `/THIRD-PARTY/`).