### PR TITLE
Update Eclipse platform to 2020-03 to fix issue with checkboxes on GTK + Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Don't unload the Salt document graph when text viewer is closed, notify the project manager instead.
   This will only unload the document graph when no other editor has opened the document.
+- Updated the Eclipse platform to the 2020-03 release
 
 ### Fixed
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,7 +9,7 @@ authors:
   given-names: Thomas
   orcid: https://orcid.org/0000-0003-3731-2422
 version: 0.4.0-SNAPSHOT
-date-released: 2020-05-19
+date-released: 2020-05-21
 references:
 - type: software
   title: SWT Resource Manager

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -107,7 +107,7 @@ references:
     directory.
 - type: software
   title: ch.qos.logback.core
-  version: 1.1.2.v20160208-0839
+  version: 1.1.2.v20200204-2150
   license: EPL-1.0
   authors:
   - name: QOS.ch
@@ -205,7 +205,7 @@ references:
     directory.
 - type: software
   title: org.apache.felix.scr
-  version: 2.1.14.v20190123-1619
+  version: 2.1.16.v20200110-1820
   license: Apache-2.0
   authors:
   - name: Apache Software Foundation
@@ -221,7 +221,7 @@ references:
     directory.
 - type: software
   title: org.eclipse.core.commands
-  version: 3.9.600.v20191122-2109
+  version: 3.9.700.v20191217-1850
   license: EPL-2.0
   authors:
   - name: The Eclipse Foundation
@@ -230,7 +230,7 @@ references:
     directory.
 - type: software
   title: org.eclipse.core.contenttype
-  version: 3.7.500.v20190916-2125
+  version: 3.7.600.v20200124-1609
   license: EPL-2.0
   authors:
   - name: The Eclipse Foundation
@@ -239,7 +239,7 @@ references:
     directory.
 - type: software
   title: org.eclipse.core.databinding
-  version: 1.7.700.v20191122-2109
+  version: 1.8.0.v20200205-2008
   license: EPL-2.0
   authors:
   - name: The Eclipse Foundation
@@ -248,7 +248,7 @@ references:
     directory.
 - type: software
   title: org.eclipse.core.databinding.observable
-  version: 1.8.100.v20191118-0932
+  version: 1.9.0.v20200205-2119
   license: EPL-2.0
   authors:
   - name: The Eclipse Foundation
@@ -257,7 +257,7 @@ references:
     directory.
 - type: software
   title: org.eclipse.core.databinding.property
-  version: 1.7.200.v20191105-1311
+  version: 1.8.0.v20200124-0715
   license: EPL-2.0
   authors:
   - name: The Eclipse Foundation
@@ -266,7 +266,7 @@ references:
     directory.
 - type: software
   title: org.eclipse.core.expressions
-  version: 3.6.600.v20191122-2104
+  version: 3.6.700.v20200212-1751
   license: EPL-2.0
   authors:
   - name: The Eclipse Foundation
@@ -275,7 +275,7 @@ references:
     directory.
 - type: software
   title: org.eclipse.core.jobs
-  version: 3.10.600.v20191122-2104
+  version: 3.10.700.v20200106-1020
   license: EPL-2.0
   authors:
   - name: The Eclipse Foundation
@@ -284,7 +284,7 @@ references:
     directory.
 - type: software
   title: org.eclipse.core.runtime
-  version: 3.17.0.v20191122-2104
+  version: 3.17.100.v20200203-0917
   license: EPL-2.0
   authors:
   - name: The Eclipse Foundation
@@ -302,7 +302,7 @@ references:
     directory.
 - type: software
   title: org.eclipse.e4.core.commands
-  version: 0.12.800.v20190926-0808
+  version: 0.12.900.v20200110-1732
   license: EPL-2.0
   authors:
   - name: The Eclipse Foundation
@@ -311,7 +311,7 @@ references:
     directory.
 - type: software
   title: org.eclipse.e4.core.contexts
-  version: 1.8.300.v20191017-1404
+  version: 1.8.400.v20191217-1710
   license: EPL-2.0
   authors:
   - name: The Eclipse Foundation
@@ -329,7 +329,7 @@ references:
     directory.
 - type: software
   title: org.eclipse.e4.core.di.annotations
-  version: 1.6.500.v20190925-0538
+  version: 1.6.600.v20191216-2352
   license: EPL-2.0
   authors:
   - name: The Eclipse Foundation
@@ -338,7 +338,7 @@ references:
     directory.
 - type: software
   title: org.eclipse.e4.core.di.extensions
-  version: 0.15.400.v20191122-2104
+  version: 0.15.500.v20200106-1259
   license: EPL-2.0
   authors:
   - name: The Eclipse Foundation
@@ -347,7 +347,7 @@ references:
     directory.
 - type: software
   title: org.eclipse.e4.core.di.extensions.supplier
-  version: 0.15.400.v20190709-0707
+  version: 0.15.500.v20200106-1259
   license: EPL-2.0
   authors:
   - name: The Eclipse Foundation
@@ -356,7 +356,7 @@ references:
     directory.
 - type: software
   title: org.eclipse.e4.core.services
-  version: 2.2.100.v20191122-2104
+  version: 2.2.200.v20200127-0814
   license: EPL-2.0
   authors:
   - name: The Eclipse Foundation
@@ -365,7 +365,7 @@ references:
     directory.
 - type: software
   title: org.eclipse.e4.emf.xpath
-  version: 0.2.500.v20191021-1408
+  version: 0.2.600.v20191216-0805
   license: EPL-2.0
   authors:
   - name: The Eclipse Foundation
@@ -374,7 +374,7 @@ references:
     directory.
 - type: software
   title: org.eclipse.e4.ui.bindings
-  version: 0.12.700.v20191105-1310
+  version: 0.12.800.v20191216-0805
   license: EPL-2.0
   authors:
   - name: The Eclipse Foundation
@@ -383,7 +383,7 @@ references:
     directory.
 - type: software
   title: org.eclipse.e4.ui.css.core
-  version: 0.12.900.v20191106-1716
+  version: 0.12.1000.v20200129-0903
   license: EPL-2.0
   authors:
   - name: The Eclipse Foundation
@@ -392,7 +392,7 @@ references:
     directory.
 - type: software
   title: org.eclipse.e4.ui.css.swt
-  version: 0.13.700.v20191113-1031
+  version: 0.13.900.v20200203-0840
   license: EPL-2.0
   authors:
   - name: The Eclipse Foundation
@@ -401,7 +401,7 @@ references:
     directory.
 - type: software
   title: org.eclipse.e4.ui.css.swt.theme
-  version: 0.12.500.v20191125-1011
+  version: 0.12.600.v20200124-0005
   license: EPL-2.0
   authors:
   - name: The Eclipse Foundation
@@ -410,7 +410,7 @@ references:
     directory.
 - type: software
   title: org.eclipse.e4.ui.di
-  version: 1.2.700.v20191114-0830
+  version: 1.2.800.v20200128-0855
   license: EPL-2.0
   authors:
   - name: The Eclipse Foundation
@@ -419,7 +419,7 @@ references:
     directory.
 - type: software
   title: org.eclipse.e4.ui.dialogs
-  version: 1.1.600.v20190814-0636
+  version: 1.1.700.v20200201-1719
   license: EPL-2.0
   authors:
   - name: The Eclipse Foundation
@@ -428,7 +428,7 @@ references:
     directory.
 - type: software
   title: org.eclipse.e4.ui.model.workbench
-  version: 2.1.600.v20191106-1503
+  version: 2.1.700.v20200113-1422
   license: EPL-2.0
   authors:
   - name: The Eclipse Foundation
@@ -446,7 +446,7 @@ references:
     directory.
 - type: software
   title: org.eclipse.e4.ui.widgets
-  version: 1.2.600.v20190926-0808
+  version: 1.2.700.v20191222-1048
   license: EPL-2.0
   authors:
   - name: The Eclipse Foundation
@@ -455,7 +455,7 @@ references:
     directory.
 - type: software
   title: org.eclipse.e4.ui.workbench
-  version: 1.11.0.v20191120-1917
+  version: 1.11.200.v20200205-1503
   license: EPL-2.0
   authors:
   - name: The Eclipse Foundation
@@ -464,7 +464,7 @@ references:
     directory.
 - type: software
   title: org.eclipse.e4.ui.workbench.addons.swt
-  version: 1.3.700.v20191030-1314
+  version: 1.3.800.v20191212-1231
   license: EPL-2.0
   authors:
   - name: The Eclipse Foundation
@@ -473,7 +473,7 @@ references:
     directory.
 - type: software
   title: org.eclipse.e4.ui.workbench.renderers.swt
-  version: 0.14.900.v20191114-0715
+  version: 0.14.1100.v20200217-1217
   license: EPL-2.0
   authors:
   - name: The Eclipse Foundation
@@ -482,7 +482,7 @@ references:
     directory.
 - type: software
   title: org.eclipse.e4.ui.workbench.swt
-  version: 0.14.800.v20190930-1643
+  version: 0.14.900.v20200213-1442
   license: EPL-2.0
   authors:
   - name: The Eclipse Foundation
@@ -491,7 +491,7 @@ references:
     directory.
 - type: software
   title: org.eclipse.e4.ui.workbench3
-  version: 0.15.300.v20190926-0808
+  version: 0.15.400.v20191216-0805
   license: EPL-2.0
   authors:
   - name: The Eclipse Foundation
@@ -500,7 +500,7 @@ references:
     directory.
 - type: software
   title: org.eclipse.emf.common
-  version: 2.17.0.v20190920-0401
+  version: 2.18.0.v20191225-1014
   license: EPL-2.0
   authors:
   - name: The Eclipse Foundation
@@ -509,7 +509,7 @@ references:
     directory.
 - type: software
   title: org.eclipse.emf.ecore
-  version: 2.20.0.v20190920-0401
+  version: 2.21.0.v20200127-1342
   license: EPL-2.0
   authors:
   - name: The Eclipse Foundation
@@ -536,7 +536,7 @@ references:
     directory.
 - type: software
   title: org.eclipse.equinox.app
-  version: 1.4.300.v20190815-1535
+  version: 1.4.400.v20191212-0743
   license: EPL-2.0
   authors:
   - name: The Eclipse Foundation
@@ -545,7 +545,7 @@ references:
     directory.
 - type: software
   title: org.eclipse.equinox.common
-  version: 3.10.600.v20191004-1420
+  version: 3.11.0.v20200206-0817
   license: EPL-2.0
   authors:
   - name: The Eclipse Foundation
@@ -563,7 +563,7 @@ references:
     directory.
 - type: software
   title: org.eclipse.equinox.preferences
-  version: 3.7.600.v20191017-2055
+  version: 3.7.700.v20191213-1901
   license: EPL-2.0
   authors:
   - name: The Eclipse Foundation
@@ -572,7 +572,7 @@ references:
     directory.
 - type: software
   title: org.eclipse.equinox.registry
-  version: 3.8.600.v20191017-2055
+  version: 3.8.700.v20200121-1457
   license: EPL-2.0
   authors:
   - name: The Eclipse Foundation
@@ -581,7 +581,7 @@ references:
     directory.
 - type: software
   title: org.eclipse.help
-  version: 3.8.600.v20191123-0656
+  version: 3.8.700.v20191212-1123
   license: EPL-2.0
   authors:
   - name: The Eclipse Foundation
@@ -590,7 +590,7 @@ references:
     directory.
 - type: software
   title: org.eclipse.jface
-  version: 3.18.0.v20191122-2109
+  version: 3.19.0.v20200218-1607
   license: EPL-2.0
   authors:
   - name: The Eclipse Foundation
@@ -599,7 +599,7 @@ references:
     directory.
 - type: software
   title: org.eclipse.jface.databinding
-  version: 1.9.200.v20191113-1050
+  version: 1.11.0.v20200205-2119
   license: EPL-2.0
   authors:
   - name: The Eclipse Foundation
@@ -608,7 +608,7 @@ references:
     directory.
 - type: software
   title: org.eclipse.jface.text
-  version: 3.16.100.v20191203-1634
+  version: 3.16.200.v20200218-0828
   license: EPL-2.0
   authors:
   - name: The Eclipse Foundation
@@ -626,7 +626,7 @@ references:
     directory.
 - type: software
   title: org.eclipse.osgi
-  version: 3.15.100.v20191114-1701
+  version: 3.15.200.v20200214-1600
   license: EPL-2.0
   authors:
   - name: The Eclipse Foundation
@@ -653,7 +653,7 @@ references:
     directory.
 - type: software
   title: org.eclipse.swt
-  version: 3.113.0.v20191204-0601
+  version: 3.114.0.v20200304-0601
   license: EPL-2.0
   authors:
   - name: The Eclipse Foundation
@@ -662,7 +662,7 @@ references:
     directory.
 - type: software
   title: org.eclipse.swt.cocoa.macosx.x86_64
-  version: 3.113.0.v20191204-0601
+  version: 3.114.0.v20200304-0601
   license: EPL-1.0
   authors:
   - name: The Eclipse Foundation
@@ -671,7 +671,7 @@ references:
     directory.
 - type: software
   title: org.eclipse.swt.gtk.linux.x86_64
-  version: 3.113.0.v20191204-0601
+  version: 3.114.0.v20200304-0601
   license: EPL-2.0
   authors:
   - name: The Eclipse Foundation
@@ -680,7 +680,7 @@ references:
     directory.
 - type: software
   title: org.eclipse.swt.win32.win32.x86_64
-  version: 3.113.0.v20191204-0601
+  version: 3.114.0.v20200304-0601
   license: EPL-1.0
   authors:
   - name: The Eclipse Foundation
@@ -689,7 +689,7 @@ references:
     directory.
 - type: software
   title: org.eclipse.text
-  version: 3.10.0.v20191122-2108
+  version: 3.10.100.v20200217-1239
   license: EPL-2.0
   authors:
   - name: The Eclipse Foundation
@@ -698,7 +698,7 @@ references:
     directory.
 - type: software
   title: org.eclipse.ui
-  version: 3.115.0.v20191127-1056
+  version: 3.116.0.v20200203-1308
   license: EPL-2.0
   authors:
   - name: The Eclipse Foundation
@@ -706,7 +706,7 @@ references:
   notes: More license information can be found in the THIRD-PARTY/org.eclipse.ui directory.
 - type: software
   title: org.eclipse.ui.workbench
-  version: 3.117.0.v20191126-1131
+  version: 3.118.0.v20200222-0719
   license: EPL-2.0
   authors:
   - name: The Eclipse Foundation

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <tycho.version>1.5.1</tycho.version>
-        <eclipse-repo.url>http://download.eclipse.org/releases/2019-06</eclipse-repo.url>
     </properties>
     <!-- MODULES -->
     <modules>

--- a/releng/org.corpus_tools.hexatomic.target/org.corpus_tools.hexatomic.target.target
+++ b/releng/org.corpus_tools.hexatomic.target/org.corpus_tools.hexatomic.target.target
@@ -1,26 +1,26 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="Hexatomic Target Platform Definition" sequenceNumber="1589888974">
+<target name="Hexatomic Target Platform Definition" sequenceNumber="1590060969">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="true" type="InstallableUnit">
-      <unit id="org.eclipse.platform.sdk" version="4.14.0.I20191210-0610"/>
-      <unit id="org.eclipse.equinox.sdk.feature.group" version="3.20.0.v20191122-2104"/>
-      <unit id="org.eclipse.emf.common" version="2.17.0.v20190920-0401"/>
-      <unit id="org.eclipse.e4.core.services" version="2.2.100.v20191122-2104"/>
+      <unit id="org.eclipse.platform.sdk" version="4.15.0.I20200305-0155"/>
+      <unit id="org.eclipse.equinox.sdk.feature.group" version="3.20.100.v20200303-1901"/>
+      <unit id="org.eclipse.emf.common" version="2.18.0.v20191225-1014"/>
+      <unit id="org.eclipse.e4.core.services" version="2.2.200.v20200127-0814"/>
       <unit id="org.eclipse.zest.core" version="1.5.300.201606061308"/>
       <unit id="org.eclipse.zest.layouts" version="1.1.300.201606061308"/>
-      <unit id="org.eclipse.jdt.junit5.runtime" version="1.0.700.v20191009-0503"/>
-      <unit id="org.junit.jupiter.api" version="5.5.1.v20190826-0900"/>
-      <unit id="org.junit.jupiter.engine" version="5.5.1.v20190826-0900"/>
-      <unit id="org.junit.platform.engine" version="1.5.1.v20190826-0900"/>
-      <unit id="org.junit.vintage.engine" version="5.5.1.v20190826-0900"/>
+      <unit id="org.eclipse.jdt.junit5.runtime" version="1.0.800.v20200214-0716"/>
+      <unit id="org.junit.jupiter.api" version="5.6.0.v20200203-2009"/>
+      <unit id="org.junit.jupiter.engine" version="5.6.0.v20200203-2009"/>
+      <unit id="org.junit.platform.engine" version="1.6.0.v20200203-2009"/>
+      <unit id="org.junit.vintage.engine" version="5.6.0.v20200203-2009"/>
       <unit id="org.eclipse.swtbot.e4.finder" version="2.8.0.201906121535"/>
       <unit id="org.eclipse.swtbot.generator" version="2.8.0.201906121535"/>
       <unit id="org.eclipse.swtbot.go" version="2.8.0.201906121535"/>
       <unit id="org.eclipse.swtbot.swt.finder" version="2.8.0.201906121535"/>
-      <unit id="org.eclipse.jface" version="3.18.0.v20191122-2109"/>
-      <repository location="http://download.eclipse.org/releases/2019-12/"/>
+      <unit id="org.eclipse.jface" version="3.19.0.v20200218-1607"/>
+      <repository location="http://download.eclipse.org/releases/2020-03/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="true" type="InstallableUnit">
       <unit id="org.slf4j.api" version="1.7.10.v20170428-1633"/>

--- a/releng/org.corpus_tools.hexatomic.target/org.corpus_tools.hexatomic.target.tpd
+++ b/releng/org.corpus_tools.hexatomic.target/org.corpus_tools.hexatomic.target.tpd
@@ -2,7 +2,7 @@ target 'Hexatomic Target Platform Definition'
 
 with requirements source configurePhase
 
-location 'http://download.eclipse.org/releases/2019-12/' {
+location 'http://download.eclipse.org/releases/2020-03/' {
 	org.eclipse.platform.sdk
 	org.eclipse.equinox.sdk.feature.group
 	org.eclipse.emf.common

--- a/tests/org.corpus_tools.hexatomic.it.tests/pom.xml
+++ b/tests/org.corpus_tools.hexatomic.it.tests/pom.xml
@@ -26,6 +26,14 @@
                     <application>org.eclipse.e4.ui.workbench.swt.E4Application</application>
                     <runOrder>alphabetical</runOrder>
                     <threadCount>1</threadCount>
+                    <environmentVariables>
+	                    <!--  
+	                    This will ensure the XServer backend is used on Linux instead of Wayland.
+	                    The ",*" is important so that GDK is trying other backends e.g. on Windows or Mac
+	                    if x11 is not available.
+	                    -->
+                    	<GDK_BACKEND>x11,*</GDK_BACKEND>
+                    </environmentVariables>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help. -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] The *Unreleased* section in CHANGELOG.md has been amended to reflect the changes in this PR
- [x] Build (`mvn verify`) was run locally and any changes were pushed
- [x] The pull request is against the correct branch (`master` for bug fixes, `develop` for new functionality)


## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The checkboxes are not properly drawn when selected and part of a dialog with grey background. This is a [long-standing bug in Eclipse](https://bugs.eclipse.org/bugs/show_bug.cgi?id=546552) which was fixed in their master branch some time ago, but has finally landed in a released Eclipse platform.

![grafik](https://user-images.githubusercontent.com/2168104/82556109-606f4e00-9b69-11ea-8c41-84895edac518.png)


Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Selected checkboxes on grey background are rendered correctly

![grafik](https://user-images.githubusercontent.com/2168104/82555751-a37cf180-9b68-11ea-83ac-899446613d43.png)

- UI tests under Linux/GTK that are executed with Maven now always use the X11 server (and not Wayland, which seems to be buggy with SWTBot)

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Does this introduce new dependencies?

- [X] Yes
- [ ] No

If this introduces new dependencies:

- [x] [Dependencies and citation templates](https://github.com/hexatomic/hexatomic/tree/develop/releng/templates) have been updated where necessary

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

# Checklist for maintainers

## Releases

- [ ] Do **NOT** push the green merge button on GitHub.  
Follow the latest version of the [developer/maintainer docs](https://hexatomic.github.io/hexatomic/dev/) for making releases.
- [ ] License and citation information for dependencies are complete (each dependency has a folder in `/THIRD-PARTY/`).