### PR TITLE
Aggregate test coverage results in Maven

### DIFF
--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -7,6 +7,15 @@
 		<artifactId>org.corpus_tools.hexatomic.root</artifactId>
 		<version>0.4.0-SNAPSHOT</version>
 	</parent>
+	
+	<properties>
+		<!-- 
+		The bundles are tested by seperate test bundles and test coverage results are 
+		aggregated into a report project. Tell SonarCloud to use the aggregated data.
+		-->
+		<sonar.coverage.jacoco.xmlReportPaths>${basedir}/../../${aggregate.report.dir}</sonar.coverage.jacoco.xmlReportPaths>
+	</properties>
+	
 	<modules>
 		<module>org.corpus_tools.hexatomic.core</module>
 		<module>org.corpus_tools.hexatomic.corpusedit</module>

--- a/docs/dev/src/development/automated-tests/README.md
+++ b/docs/dev/src/development/automated-tests/README.md
@@ -23,10 +23,10 @@ To specifically run the tests and not install the artifacts, use `mvn integratio
 Unlike unit tests, `mvn test` will not work for integration tests, as the Tycho Surefire Plugin requires
 the bundles to be packaged, which happens in Maven's `package` phase, which comes after `test` and before `integration-test`.
 
+To learn more about the Maven build lifecycle, read the [Maven Lifecycles Reference](http://web.archive.org/web/20191128092924/https://maven.apache.org/ref/3.6.2/maven-core/lifecycles.html).
+
 You can also generate a test code coverage report by executing `mvn verify site -Pcoverage`. 
 The generated report will be located under `tests/org.corpus_tools.hexatomic.tests.report/target/site/jacoco-aggregate/index.html`.
-
-To learn more about the Maven build lifecycle, read the [Maven Lifecycles Reference](http://web.archive.org/web/20191128092924/https://maven.apache.org/ref/3.6.2/maven-core/lifecycles.html).
 
 ## Execute tests in Eclipse
 

--- a/docs/dev/src/development/automated-tests/README.md
+++ b/docs/dev/src/development/automated-tests/README.md
@@ -23,6 +23,9 @@ To specifically run the tests and not install the artifacts, use `mvn integratio
 Unlike unit tests, `mvn test` will not work for integration tests, as the Tycho Surefire Plugin requires
 the bundles to be packaged, which happens in Maven's `package` phase, which comes after `test` and before `integration-test`.
 
+You can also generate a test code coverage report by executing `mvn verify site -Pcoverage`. 
+The generated report will be located under `tests/org.corpus_tools.hexatomic.tests.report/target/site/jacoco-aggregate/index.html`.
+
 To learn more about the Maven build lifecycle, read the [Maven Lifecycles Reference](http://web.archive.org/web/20191128092924/https://maven.apache.org/ref/3.6.2/maven-core/lifecycles.html).
 
 ## Execute tests in Eclipse

--- a/pom.xml
+++ b/pom.xml
@@ -16,11 +16,9 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<tycho.version>1.6.0</tycho.version>
+		<jacoco.version>0.8.5</jacoco.version>
 		<sonar.coverage.jacoco.xmlReportPaths>
-			./tests/org.corpus_tools.hexatomic.core.tests/target/site/jacoco/jacoco.xml,
-			./tests/org.corpus_tools.hexatomic.grid.tests/target/site/jacoco/jacoco.xml,
-			./tests/org.corpus_tools.hexatomic.graph.tests/target/site/jacoco/jacoco.xml,
-			./tests/org.corpus_tools.hexatomic.it.tests/target/site/jacoco/jacoco.xml
+			./tests/org.corpus_tools.hexatomic.tests.report/target/site/jacoco-aggregate/jacoco.xml
 		</sonar.coverage.jacoco.xmlReportPaths>
 	</properties>
 	<!-- MODULES -->
@@ -250,6 +248,29 @@
 			</plugin>
 		</plugins>
 	</build>
+	
+	<profiles>
+		<profile>
+			<id>coverage</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.jacoco</groupId>
+						<artifactId>jacoco-maven-plugin</artifactId>
+						<version>${jacoco.version}</version>
+						<executions>
+							<execution>
+								<id>prepare-agent</id>
+								<goals>
+									<goal>prepare-agent</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 
 	<!-- JAVADOC REPORTING -->
 	<!--<reporting><excludeDefaults>true</excludeDefaults><plugins><plugin><groupId>org.apache.maven.plugins</groupId><artifactId>maven-javadoc-plugin</artifactId><version>3.1.1</version><reportSets><reportSet><reports><report>aggregate-no-fork</report><report>test-aggregate-no-fork</report></reports></reportSet></reportSets></plugin></plugins></reporting> -->

--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,11 @@
 					<artifactId>antlr4-maven-plugin</artifactId>
 					<version>4.7.2</version>
 				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-site-plugin</artifactId>
+					<version>3.9.0</version>
+				</plugin>
 			</plugins>
 		</pluginManagement>
 		<plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -17,9 +17,7 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<tycho.version>1.6.0</tycho.version>
 		<jacoco.version>0.8.5</jacoco.version>
-		<sonar.coverage.jacoco.xmlReportPaths>
-			./tests/org.corpus_tools.hexatomic.tests.report/target/site/jacoco-aggregate/jacoco.xml
-		</sonar.coverage.jacoco.xmlReportPaths>
+		 <aggregate.report.dir>tests/org.corpus_tools.hexatomic.tests.report/target/site/jacoco-aggregate/jacoco.xml</aggregate.report.dir>
 	</properties>
 	<!-- MODULES -->
 	<modules>

--- a/pom.xml
+++ b/pom.xml
@@ -15,9 +15,10 @@
 		<license-maven-plugin.version>2.0.0</license-maven-plugin.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+		<maven.compiler.source>1.8</maven.compiler.source>
 		<tycho.version>1.6.0</tycho.version>
 		<jacoco.version>0.8.5</jacoco.version>
-		 <aggregate.report.dir>tests/org.corpus_tools.hexatomic.tests.report/target/site/jacoco-aggregate/jacoco.xml</aggregate.report.dir>
+		<aggregate.report.dir>tests/org.corpus_tools.hexatomic.tests.report/target/site/jacoco-aggregate/jacoco.xml</aggregate.report.dir>
 	</properties>
 	<!-- MODULES -->
 	<modules>

--- a/tests/org.corpus_tools.hexatomic.tests.report/pom.xml
+++ b/tests/org.corpus_tools.hexatomic.tests.report/pom.xml
@@ -1,0 +1,84 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.corpus_tools</groupId>
+		<artifactId>org.corpus_tools.hexatomic.tests</artifactId>
+		<version>0.4.0-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>org.corpus_tools.hexatomic.tests.report</artifactId>
+	<name>Aggregate Test Report</name>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.corpus_tools</groupId>
+			<artifactId>org.corpus_tools.hexatomic.core</artifactId>
+			<version>${project.version}</version>
+			<scope>compile</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.corpus_tools</groupId>
+			<artifactId>org.corpus_tools.hexatomic.core.tests</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.corpus_tools</groupId>
+			<artifactId>org.corpus_tools.hexatomic.graph</artifactId>
+			<version>${project.version}</version>
+			<scope>compile</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.corpus_tools</groupId>
+			<artifactId>org.corpus_tools.hexatomic.graph.tests</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.corpus_tools</groupId>
+			<artifactId>org.corpus_tools.hexatomic.grid</artifactId>
+			<version>${project.version}</version>
+			<scope>compile</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.corpus_tools</groupId>
+			<artifactId>org.corpus_tools.hexatomic.grid.tests</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.corpus_tools</groupId>
+			<artifactId>org.corpus_tools.hexatomic.it.tests</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<profiles>
+		<profile>
+			<id>coverage</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.jacoco</groupId>
+						<artifactId>jacoco-maven-plugin</artifactId>
+						<version>${jacoco.version}</version>
+						<executions>
+							<execution>
+								<id>report-aggregate</id>
+								<phase>verify</phase>
+								<goals>
+									<goal>report-aggregate</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
+
+</project>

--- a/tests/org.corpus_tools.hexatomic.tests.report/pom.xml
+++ b/tests/org.corpus_tools.hexatomic.tests.report/pom.xml
@@ -11,6 +11,11 @@
 
 	<artifactId>org.corpus_tools.hexatomic.tests.report</artifactId>
 	<name>Aggregate Test Report</name>
+	
+	<properties>
+    	<sonar.coverage.jacoco.xmlReportPaths>${basedir}/../../${aggregate.report.dir}</sonar.coverage.jacoco.xmlReportPaths>
+  	</properties>
+	
 
 	<dependencies>
 		<dependency>

--- a/tests/org.corpus_tools.hexatomic.tests.report/pom.xml
+++ b/tests/org.corpus_tools.hexatomic.tests.report/pom.xml
@@ -51,6 +51,12 @@
 		</dependency>
 		<dependency>
 			<groupId>org.corpus_tools</groupId>
+			<artifactId>org.corpus_tools.hexatomic.textviewer</artifactId>
+			<version>${project.version}</version>
+			<scope>compile</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.corpus_tools</groupId>
 			<artifactId>org.corpus_tools.hexatomic.it.tests</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>

--- a/tests/org.corpus_tools.hexatomic.tests.report/pom.xml
+++ b/tests/org.corpus_tools.hexatomic.tests.report/pom.xml
@@ -12,11 +12,6 @@
 	<artifactId>org.corpus_tools.hexatomic.tests.report</artifactId>
 	<name>Aggregate Test Report</name>
 	
-	<properties>
-    	<sonar.coverage.jacoco.xmlReportPaths>${basedir}/../../${aggregate.report.dir}</sonar.coverage.jacoco.xmlReportPaths>
-  	</properties>
-	
-
 	<dependencies>
 		<dependency>
 			<groupId>org.corpus_tools</groupId>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -15,37 +15,7 @@
 		<module>org.corpus_tools.hexatomic.graph.tests</module>
 		<module>org.corpus_tools.hexatomic.grid.tests</module>
 		<module>org.corpus_tools.hexatomic.it.tests</module>
+		<module>org.corpus_tools.hexatomic.tests.report</module>
 	</modules>
-
-
-	<profiles>
-		<profile>
-			<id>coverage</id>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>org.jacoco</groupId>
-						<artifactId>jacoco-maven-plugin</artifactId>
-						<version>0.8.3</version>
-						<executions>
-							<execution>
-								<id>prepare-agent</id>
-								<goals>
-									<goal>prepare-agent</goal>
-								</goals>
-							</execution>
-							<execution>
-								<id>report</id>
-								<goals>
-									<goal>report</goal>
-								</goals>
-								<phase>verify</phase>
-							</execution>
-						</executions>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
-	</profiles>
 
 </project>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -9,6 +9,14 @@
 		<artifactId>org.corpus_tools.hexatomic.root</artifactId>
 		<version>0.4.0-SNAPSHOT</version>
 	</parent>
+	
+	<properties>
+		<!-- 
+		The bundles are tested by seperate test bundles and test coverage results are 
+		aggregated into a report project. Tell SonarCloud to use the aggregated data.
+		-->
+		<sonar.coverage.jacoco.xmlReportPaths>${basedir}/../../${aggregate.report.dir}</sonar.coverage.jacoco.xmlReportPaths>
+	</properties>
 
 	<modules>
 		<module>org.corpus_tools.hexatomic.core.tests</module>


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help. -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] The *Unreleased* section in CHANGELOG.md has been amended to reflect the changes in this PR
- [X] Build (`mvn verify`) was run locally and any changes were pushed
- [X] The pull request is against the correct branch (`master` for bug fixes, `develop` for new functionality)


## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [X] Build related changes
- [X] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
You can only create test coverage reports using the Eclipse Interface. Also the SonarCloud test coverage only pickups the test coverage of the tests itself, not the modules under test.


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Added a new aggregate test sub-project
- Documented how to generate an aggregated code coverage report in Maven
- Changed SonarCloud configuration to pickup the code coverage result of the aggregated report project.
- Fixed `mvn site` execution

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Does this introduce new dependencies?

- [ ] Yes
- [X] No

If this introduces new dependencies:

- [ ] [Dependencies and citation templates](https://github.com/hexatomic/hexatomic/tree/develop/releng/templates) have been updated where necessary

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

# Checklist for maintainers

## Releases

- [ ] Do **NOT** push the green merge button on GitHub.  
Follow the latest version of the [developer/maintainer docs](https://hexatomic.github.io/hexatomic/dev/) for making releases.
- [ ] License and citation information for dependencies are complete (each dependency has a folder in `/THIRD-PARTY/`).