### PR TITLE
Fix issues with locale auto-detection in UI tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ target/
 book/
 NOTES.md
 workspace/
+tests/**/Rerun*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update views via notification even if the object that changed was created before the view.
 - Allow to run Hexatomic on Java 11 platforms
+- Set locale in UI tests to avoid issues with auto-detected keyboard layouts
 
 ## [0.3.1] - 2019-12-16
 

--- a/bundles/org.corpus_tools.hexatomic.grid/src/main/java/org/corpus_tools/hexatomic/grid/style/LabelAccumulator.java
+++ b/bundles/org.corpus_tools.hexatomic.grid/src/main/java/org/corpus_tools/hexatomic/grid/style/LabelAccumulator.java
@@ -75,7 +75,7 @@ public class LabelAccumulator extends ColumnOverrideLabelAccumulator {
 
     int columnIndex = bodyDataLayer.getColumnIndexByPosition(columnPosition);
     List<Column> columns = bodyDataProvider.getColumns();
-    if (columns.size() != 0) {
+    if (!columns.isEmpty()) {
       ColumnType columnType = columns.get(columnIndex).getColumnType();
       if (columnType == ColumnType.SPAN_ANNOTATION) {
         // Assign the span annotation style label to cells in columns with the respective flag.

--- a/bundles/org.corpus_tools.hexatomic.grid/src/main/java/org/corpus_tools/hexatomic/grid/style/LabelAccumulator.java
+++ b/bundles/org.corpus_tools.hexatomic.grid/src/main/java/org/corpus_tools/hexatomic/grid/style/LabelAccumulator.java
@@ -75,11 +75,8 @@ public class LabelAccumulator extends ColumnOverrideLabelAccumulator {
 
     int columnIndex = bodyDataLayer.getColumnIndexByPosition(columnPosition);
     List<Column> columns = bodyDataProvider.getColumns();
-    ColumnType columnType = null;
     if (columns.size() != 0) {
-      columnType = columns.get(columnIndex).getColumnType();
-    }
-    if (columnType != null) {
+      ColumnType columnType = columns.get(columnIndex).getColumnType();
       if (columnType == ColumnType.SPAN_ANNOTATION) {
         // Assign the span annotation style label to cells in columns with the respective flag.
         configLabels.addLabel(StyleConfiguration.SPAN_ANNOTATION_CELL_STYLE);

--- a/bundles/org.corpus_tools.hexatomic.grid/src/main/java/org/corpus_tools/hexatomic/grid/style/LabelAccumulator.java
+++ b/bundles/org.corpus_tools.hexatomic.grid/src/main/java/org/corpus_tools/hexatomic/grid/style/LabelAccumulator.java
@@ -21,6 +21,8 @@
 
 package org.corpus_tools.hexatomic.grid.style;
 
+import java.util.List;
+import org.corpus_tools.hexatomic.grid.data.Column;
 import org.corpus_tools.hexatomic.grid.data.Column.ColumnType;
 import org.corpus_tools.hexatomic.grid.data.GraphDataProvider;
 import org.eclipse.nebula.widgets.nattable.layer.LabelStack;
@@ -72,13 +74,19 @@ public class LabelAccumulator extends ColumnOverrideLabelAccumulator {
     }
 
     int columnIndex = bodyDataLayer.getColumnIndexByPosition(columnPosition);
-    ColumnType columnType = bodyDataProvider.getColumns().get(columnIndex).getColumnType();
-    if (columnType == ColumnType.SPAN_ANNOTATION) {
-      // Assign the span annotation style label to cells in columns with the respective flag.
-      configLabels.addLabel(StyleConfiguration.SPAN_ANNOTATION_CELL_STYLE);
-    } else if (columnType == ColumnType.TOKEN_TEXT) {
-      // Assign the token text style label to cells in columns with the respective flag.
-      configLabels.addLabel(StyleConfiguration.TOKEN_TEXT_CELL_STYLE);
+    List<Column> columns = bodyDataProvider.getColumns();
+    ColumnType columnType = null;
+    if (columns.size() != 0) {
+      columnType = columns.get(columnIndex).getColumnType();
+    }
+    if (columnType != null) {
+      if (columnType == ColumnType.SPAN_ANNOTATION) {
+        // Assign the span annotation style label to cells in columns with the respective flag.
+        configLabels.addLabel(StyleConfiguration.SPAN_ANNOTATION_CELL_STYLE);
+      } else if (columnType == ColumnType.TOKEN_TEXT) {
+        // Assign the token text style label to cells in columns with the respective flag.
+        configLabels.addLabel(StyleConfiguration.TOKEN_TEXT_CELL_STYLE);
+      }
     }
   }
 

--- a/docs/dev/src/development/automated-tests/ui-integration-tests.md
+++ b/docs/dev/src/development/automated-tests/ui-integration-tests.md
@@ -65,3 +65,12 @@ You can set the execution order within a test class explicitly with the `@Order(
 If you integrate a new bundle that has not been tested before, you have to add the bundle manually to the 
 dependencies of `org.corpus_tools.hexatomic.it.tests`.
 Adding it to the feature or product is not enough.
+
+Note that the Hexatomic integration tests use the SWTBot *EN_US* keyboard layout.
+If you see UI tests failing on your local machine, you may have to install US English language support.
+In other words, the *locale en_US* must be available on your operating system.
+
+On Linux, you can test this with the command `locale -a`.
+If `en_US.utf8` is listed in the output, you're all set up.
+
+For more information on SWTBot's keyboard layouts, see [Keyboard Layouts in SWTBot on the Eclipse wiki](https://wiki.eclipse.org/SWTBot/Keyboard_Layouts).

--- a/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestCorpusStructure.java
+++ b/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestCorpusStructure.java
@@ -41,6 +41,7 @@ class TestCorpusStructure {
   void setup() {
     org.eclipse.swtbot.swt.finder.utils.SWTBotPreferences.KEYBOARD_STRATEGY =
         "org.eclipse.swtbot.swt.finder.keyboard.SWTKeyboardStrategy";
+    org.eclipse.swtbot.swt.finder.utils.SWTBotPreferences.KEYBOARD_LAYOUT = "EN_US";
 
     IEclipseContext ctx = ContextHelper.getEclipseContext();
 

--- a/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestCorpusStructure.java
+++ b/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestCorpusStructure.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.TestMethodOrder;
 @TestMethodOrder(OrderAnnotation.class)
 class TestCorpusStructure {
 
-  private SWTWorkbenchBot bot = new SWTWorkbenchBot(ContextHelper.getEclipseContext());
+  private SWTWorkbenchBot bot = new SWTWorkbenchBot(TestHelper.getEclipseContext());
 
   private ECommandService commandService;
   private EHandlerService handlerService;
@@ -41,9 +41,9 @@ class TestCorpusStructure {
   void setup() {
     org.eclipse.swtbot.swt.finder.utils.SWTBotPreferences.KEYBOARD_STRATEGY =
         "org.eclipse.swtbot.swt.finder.keyboard.SWTKeyboardStrategy";
-    org.eclipse.swtbot.swt.finder.utils.SWTBotPreferences.KEYBOARD_LAYOUT = "EN_US";
+    TestHelper.setKeyboardLayout();
 
-    IEclipseContext ctx = ContextHelper.getEclipseContext();
+    IEclipseContext ctx = TestHelper.getEclipseContext();
 
     projectManager = ContextInjectionFactory.make(ProjectManager.class, ctx);
 

--- a/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestGraphEditor.java
+++ b/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestGraphEditor.java
@@ -56,6 +56,7 @@ class TestGraphEditor {
   void setup() {
     org.eclipse.swtbot.swt.finder.utils.SWTBotPreferences.KEYBOARD_STRATEGY =
         "org.eclipse.swtbot.swt.finder.keyboard.SWTKeyboardStrategy";
+    org.eclipse.swtbot.swt.finder.utils.SWTBotPreferences.KEYBOARD_LAYOUT = "EN_US";
 
     IEclipseContext ctx = ContextHelper.getEclipseContext();
 

--- a/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestGraphEditor.java
+++ b/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestGraphEditor.java
@@ -42,7 +42,7 @@ import org.junit.jupiter.api.TestMethodOrder;
 @TestMethodOrder(OrderAnnotation.class)
 class TestGraphEditor {
 
-  private final SWTWorkbenchBot bot = new SWTWorkbenchBot(ContextHelper.getEclipseContext());
+  private final SWTWorkbenchBot bot = new SWTWorkbenchBot(TestHelper.getEclipseContext());
 
   private URI exampleProjectUri;
   private ECommandService commandService;
@@ -56,9 +56,9 @@ class TestGraphEditor {
   void setup() {
     org.eclipse.swtbot.swt.finder.utils.SWTBotPreferences.KEYBOARD_STRATEGY =
         "org.eclipse.swtbot.swt.finder.keyboard.SWTKeyboardStrategy";
-    org.eclipse.swtbot.swt.finder.utils.SWTBotPreferences.KEYBOARD_LAYOUT = "EN_US";
+    TestHelper.setKeyboardLayout();
 
-    IEclipseContext ctx = ContextHelper.getEclipseContext();
+    IEclipseContext ctx = TestHelper.getEclipseContext();
 
     errorService = ContextInjectionFactory.make(ErrorService.class, ctx);
     projectManager = ContextInjectionFactory.make(ProjectManager.class, ctx);

--- a/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestGridEditor.java
+++ b/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestGridEditor.java
@@ -52,7 +52,7 @@ public class TestGridEditor {
 
   private static final String TEST_ANNOTATION_VALUE = "TEST";
 
-  private SWTWorkbenchBot bot = new SWTWorkbenchBot(ContextHelper.getEclipseContext());
+  private SWTWorkbenchBot bot = new SWTWorkbenchBot(TestHelper.getEclipseContext());
 
   private URI exampleProjectUri;
   private URI overlappingExampleProjectUri;
@@ -67,9 +67,9 @@ public class TestGridEditor {
 
   @BeforeEach
   void setup() {
-    org.eclipse.swtbot.swt.finder.utils.SWTBotPreferences.KEYBOARD_LAYOUT = "EN_US";
+    TestHelper.setKeyboardLayout();
 
-    IEclipseContext ctx = ContextHelper.getEclipseContext();
+    IEclipseContext ctx = TestHelper.getEclipseContext();
 
     ctx.set(ErrorService.class, errorService);
 

--- a/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestGridEditor.java
+++ b/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestGridEditor.java
@@ -67,6 +67,8 @@ public class TestGridEditor {
 
   @BeforeEach
   void setup() {
+    org.eclipse.swtbot.swt.finder.utils.SWTBotPreferences.KEYBOARD_LAYOUT = "EN_US";
+
     IEclipseContext ctx = ContextHelper.getEclipseContext();
 
     ctx.set(ErrorService.class, errorService);

--- a/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestHelper.java
+++ b/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestHelper.java
@@ -8,22 +8,32 @@ import org.osgi.framework.Bundle;
 import org.osgi.framework.FrameworkUtil;
 
 /**
- * A helper class to get an Eclipse context in test to create {@link SWTWorkbenchBot} instances.
+ * Provides static helper methods.
+ * 
  * @author Thomas Krause
+ * @author Stephan Druskat
  *
  */
-public class ContextHelper {
-  
+public class TestHelper {
+
   /**
-   * Get the Eclipse context for testing.
+   * Get the Eclipse context for testing to create {@link SWTWorkbenchBot} instances.
+   * 
    * @return The context.
    */
   public static IEclipseContext getEclipseContext() {
     Bundle activatorBundle = FrameworkUtil.getBundle(Activator.class);
-    final IEclipseContext serviceContext = EclipseContextFactory
-        .getServiceContext(activatorBundle.getBundleContext());
+    final IEclipseContext serviceContext =
+        EclipseContextFactory.getServiceContext(activatorBundle.getBundleContext());
 
     return serviceContext.get(IWorkbench.class).getApplication().getContext();
+  }
+
+  /**
+   * Sets the SWTBot keyboard layout to <code>EN_US</code>.
+   */
+  public synchronized static void setKeyboardLayout() {
+    org.eclipse.swtbot.swt.finder.utils.SWTBotPreferences.KEYBOARD_LAYOUT = "EN_US";
   }
 
 }

--- a/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestHelper.java
+++ b/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestHelper.java
@@ -16,6 +16,10 @@ import org.osgi.framework.FrameworkUtil;
  */
 public class TestHelper {
 
+  private TestHelper() {
+    // Hide default constructor
+  }
+
   /**
    * Get the Eclipse context for testing to create {@link SWTWorkbenchBot} instances.
    * 

--- a/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestHelper.java
+++ b/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestHelper.java
@@ -32,7 +32,7 @@ public class TestHelper {
   /**
    * Sets the SWTBot keyboard layout to <code>EN_US</code>.
    */
-  public synchronized static void setKeyboardLayout() {
+  public static void setKeyboardLayout() {
     org.eclipse.swtbot.swt.finder.utils.SWTBotPreferences.KEYBOARD_LAYOUT = "EN_US";
   }
 

--- a/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestProjectManager.java
+++ b/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestProjectManager.java
@@ -52,7 +52,7 @@ class TestProjectManager {
 
   @BeforeEach
   void setup() {
-    IEclipseContext ctx = ContextHelper.getEclipseContext();
+    IEclipseContext ctx = TestHelper.getEclipseContext();
 
     bot = new SWTWorkbenchBot(ctx);
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help. -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] The *Unreleased* section in CHANGELOG.md has been amended to reflect the changes in this PR
- [x] Build (`mvn verify`) was run locally and any changes were pushed
- [x] The pull request is against the correct branch (`master` for bug fixes, `develop` for new functionality)


## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #127 

This issue popped up again with failing tests on a system with `LANG=en_GB.UTF-8`.
Per default, SWTBot auto-detects the locale and tries to use the respective keyboard layout. Tests fail if it cannot be found for keyboard input.


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Fixes #127
- Explicitly sets the keyboard layout for SWTBot to `EN_US`, which is included in SWTBot.
- Tests may still fail if `en_US` is not available on a system at all, but this is explained in the dev docs.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Does this introduce new dependencies?

- [ ] Yes
- [x] No

If this introduces new dependencies:

- [ ] [Dependencies and citation templates](https://github.com/hexatomic/hexatomic/tree/develop/releng/templates) have been updated where necessary

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

# Checklist for maintainers

## Releases

- [ ] Do **NOT** push the green merge button on GitHub.  
Follow the latest version of the [developer/maintainer docs](https://hexatomic.github.io/hexatomic/dev/) for making releases.
- [ ] License and citation information for dependencies are complete (each dependency has a folder in `/THIRD-PARTY/`).