### PR TITLE
SWTBot NatTable Repository was pointing to the "latest" release.

### DIFF
--- a/releng/org.corpus_tools.hexatomic.target/org.corpus_tools.hexatomic.target.target
+++ b/releng/org.corpus_tools.hexatomic.target/org.corpus_tools.hexatomic.target.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="Hexatomic Target Platform Definition" sequenceNumber="1590060969">
+<target name="Hexatomic Target Platform Definition" sequenceNumber="1592811653">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="true" type="InstallableUnit">
       <unit id="org.eclipse.platform.sdk" version="4.15.0.I20200305-0155"/>
@@ -43,7 +43,7 @@
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="true" type="InstallableUnit">
       <unit id="org.eclipse.swtbot.nebula.nattable.finder" version="2.8.0.201906121535"/>
-      <repository location="https://download.eclipse.org/technology/swtbot/releases/latest/"/>
+      <repository location="https://download.eclipse.org/technology/swtbot/releases/2.8.0/"/>
     </location>
   </locations>
 </target>

--- a/releng/org.corpus_tools.hexatomic.target/org.corpus_tools.hexatomic.target.tpd
+++ b/releng/org.corpus_tools.hexatomic.target/org.corpus_tools.hexatomic.target.tpd
@@ -44,6 +44,6 @@ location 'http://download.eclipse.org/nattable/releases/1.6.0/repository/' {
 }
 
 // SWTBot for NatTable
-location 'https://download.eclipse.org/technology/swtbot/releases/latest/' {
+location 'https://download.eclipse.org/technology/swtbot/releases/2.8.0/' {
 	org.eclipse.swtbot.nebula.nattable.finder [2.8.0, 3.0.0)
 }


### PR DESCRIPTION
Since this was updated to 3.0.0, our target platform did not work anymore. Using now the explicit release repository to avoid this problem in the feature.

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help. -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] The *Unreleased* section in CHANGELOG.md has been amended to reflect the changes in this PR
- [X] Build (`mvn verify`) was run locally and any changes were pushed
- [X] The pull request is against the correct branch (`master` for bug fixes, `develop` for new functionality)


## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [X] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Build is failing because the repository in the target platform does not contain the correct version of the plugin

Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Using <https://download.eclipse.org/technology/swtbot/releases/2.8.0/> P2 repository

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Does this introduce new dependencies?

- [ ] Yes
- [X] No

If this introduces new dependencies:

- [ ] [Dependencies and citation templates](https://github.com/hexatomic/hexatomic/tree/develop/releng/templates) have been updated where necessary

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

# Checklist for maintainers

## Releases

- [ ] Do **NOT** push the green merge button on GitHub.  
Follow the latest version of the [developer/maintainer docs](https://hexatomic.github.io/hexatomic/dev/) for making releases.
- [ ] License and citation information for dependencies are complete (each dependency has a folder in `/THIRD-PARTY/`).