### PR TITLE
Allow to override keyboard layout and fix zoom in/out tests in GraphEditor

### DIFF
--- a/bundles/org.corpus_tools.hexatomic.graph/src/main/java/org/corpus_tools/hexatomic/graph/GraphEditor.java
+++ b/bundles/org.corpus_tools.hexatomic.graph/src/main/java/org/corpus_tools/hexatomic/graph/GraphEditor.java
@@ -675,9 +675,10 @@ public class GraphEditor {
       Viewport viewPort = viewer.getGraphControl().getViewport();
       Point loc = viewPort.getViewLocation();
 
-      if (e.character == '+' && (e.stateMask & SWT.CTRL) != 0) {
+      if ((e.character == '+' || e.keyCode == SWT.KEYPAD_ADD) && (e.stateMask & SWT.CTRL) != 0) {
         zoomGraphView(2.0, loc);
-      } else if (e.character == '-' && (e.stateMask & SWT.CTRL) != 0) {
+      } else if ((e.character == '-' || e.keyCode == SWT.KEYPAD_SUBTRACT)
+          && (e.stateMask & SWT.CTRL) != 0) {
         zoomGraphView(0.5, loc);
       } else {
         // Prepare scroll

--- a/bundles/org.corpus_tools.hexatomic.graph/src/main/java/org/corpus_tools/hexatomic/graph/GraphEditor.java
+++ b/bundles/org.corpus_tools.hexatomic.graph/src/main/java/org/corpus_tools/hexatomic/graph/GraphEditor.java
@@ -669,16 +669,24 @@ public class GraphEditor {
       // Only react to key pressed, but not the released event
     }
 
+    private boolean isZoomInKey(KeyEvent e) {
+      return (e.character == '+' || e.keyCode == SWT.KEYPAD_ADD) && (e.stateMask & SWT.CTRL) != 0;
+    }
+
+    private boolean isZoomOutKey(KeyEvent e) {
+      return (e.character == '-' || e.keyCode == SWT.KEYPAD_SUBTRACT)
+          && (e.stateMask & SWT.CTRL) != 0;
+    }
+
     @Override
     public void keyPressed(KeyEvent e) {
       
       Viewport viewPort = viewer.getGraphControl().getViewport();
       Point loc = viewPort.getViewLocation();
 
-      if ((e.character == '+' || e.keyCode == SWT.KEYPAD_ADD) && (e.stateMask & SWT.CTRL) != 0) {
+      if (isZoomInKey(e)) {
         zoomGraphView(2.0, loc);
-      } else if ((e.character == '-' || e.keyCode == SWT.KEYPAD_SUBTRACT)
-          && (e.stateMask & SWT.CTRL) != 0) {
+      } else if (isZoomOutKey(e)) {
         zoomGraphView(0.5, loc);
       } else {
         // Prepare scroll

--- a/docs/dev/src/development/automated-tests/README.md
+++ b/docs/dev/src/development/automated-tests/README.md
@@ -12,6 +12,8 @@ E.g. tests for classes of the `org.corpus_tools.hexatomic.core` bundle should be
 If you add a new bundle, always also create a corresponding test bundle.
 
 The special bundle `org.corpus_tools.hexatomic.it.tests` is used for [integration tests](http://web.archive.org/web/20190928235028/https://en.wikipedia.org/wiki/Integration_testing) on the whole application.
+There can be failures executing the integration tests if the keyboard layout of the system is unsupported or wrongly detected.
+See the [UI integration tests](./ui-integration-tests.html#issues-with-keyboard-layout-and-integration-tests) section for hints how to fix these failures.
 
 
 ## Execute tests with Maven

--- a/docs/dev/src/development/automated-tests/README.md
+++ b/docs/dev/src/development/automated-tests/README.md
@@ -13,7 +13,7 @@ If you add a new bundle, always also create a corresponding test bundle.
 
 The special bundle `org.corpus_tools.hexatomic.it.tests` is used for [integration tests](http://web.archive.org/web/20190928235028/https://en.wikipedia.org/wiki/Integration_testing) on the whole application.
 There can be failures executing the integration tests if the keyboard layout of the system is unsupported or wrongly detected.
-See the [UI integration tests](./ui-integration-tests.html#issues-with-keyboard-layout-and-integration-tests) section for hints how to fix these failures.
+See the [UI integration tests](./ui-integration-tests.html#issues-with-keyboard-layout-and-integration-tests) section for hints on how to fix these failures.
 
 
 ## Execute tests with Maven

--- a/docs/dev/src/development/automated-tests/ui-integration-tests.md
+++ b/docs/dev/src/development/automated-tests/ui-integration-tests.md
@@ -1,5 +1,7 @@
 # Use interface integration tests
 
+## Adding new integration tests
+
 To add user interface integration tests add new test cases to the special bundle `org.corpus_tools.hexatomic.it.tests`.
 The tests are executed with SWTBot, a testing tool for user interfaces.
 To learn how to use SWTBot, you can read the documentation on the [SWTBot homepage](http://web.archive.org/web/20191129101118/https://www.eclipse.org/swtbot/), or Lars Vogel's [SWTBot tutorial](http://web.archive.org/web/20191129101301/https://www.vogella.com/tutorials/SWTBot/article.html).
@@ -66,8 +68,11 @@ If you integrate a new bundle that has not been tested before, you have to add t
 dependencies of `org.corpus_tools.hexatomic.it.tests`.
 Adding it to the feature or product is not enough.
 
+## Issues with keyboard layout and integration tests
+
 Note that the SWTBot-based integration tests try to detect the keyboard layout automatically using the system locale.
 For example, `de_DE.UTF` would result in the keyboard layout `DE_DE`.
 This can lead to test errors when the locale is not consistent with the keyboard layout (e.g. some programmers prefer English keyboard layouts, which would be `EN_US` or `MAC_EN_US`, while still using their native locale).
 To enforce a specific keyboard layout for the tests, set the `SWTBOT_KEYBOARD_LAYOUT` environment variable to the layout you want to select.
+This can also be helpful if SWTBot does not provide a keyboard layout for the current locale, e.g. there is **no `EN_GB` layout** but you can still enforce the very similar `EN_US` layout.
 For more information on SWTBot's keyboard layouts, see [Keyboard Layouts in SWTBot on the Eclipse wiki](https://wiki.eclipse.org/SWTBot/Keyboard_Layouts).

--- a/docs/dev/src/development/automated-tests/ui-integration-tests.md
+++ b/docs/dev/src/development/automated-tests/ui-integration-tests.md
@@ -68,6 +68,6 @@ Adding it to the feature or product is not enough.
 
 Note that the SWTBot-based integration tests try to detect the keyboard layout automatically using the system locale.
 For example, `de_DE.UTF` would result in the keyboard layout `DE_DE`.
-This can lead to test errors when the locale is not consistent with the keyboard layout (e.g. some programmers prefer English keyboard layouts while still using their native locale).
+This can lead to test errors when the locale is not consistent with the keyboard layout (e.g. some programmers prefer English keyboard layouts, which would be `EN_US` or `MAC_EN_US`, while still using their native locale).
 To enforce a specific keyboard layout for the tests, set the `SWTBOT_KEYBOARD_LAYOUT` environment variable to the layout you want to select.
 For more information on SWTBot's keyboard layouts, see [Keyboard Layouts in SWTBot on the Eclipse wiki](https://wiki.eclipse.org/SWTBot/Keyboard_Layouts).

--- a/docs/dev/src/development/automated-tests/ui-integration-tests.md
+++ b/docs/dev/src/development/automated-tests/ui-integration-tests.md
@@ -66,11 +66,8 @@ If you integrate a new bundle that has not been tested before, you have to add t
 dependencies of `org.corpus_tools.hexatomic.it.tests`.
 Adding it to the feature or product is not enough.
 
-Note that the Hexatomic integration tests use the SWTBot *EN_US* keyboard layout.
-If you see UI tests failing on your local machine, you may have to install US English language support.
-In other words, the *locale en_US* must be available on your operating system.
-
-On Linux, you can test this with the command `locale -a`.
-If `en_US.utf8` is listed in the output, you're all set up.
-
+Note that the SWTBot-based integration tests try to detect the keyboard layout automatically using the system locale.
+For example, `de_DE.UTF` would result in the keyboard layout `DE_DE`.
+This can lead to test errors when the locale is not consistent with the keyboard layout (e.g. some programmers prefer English keyboard layouts while still using their native locale).
+To enforce a specific keyboard layout for the tests, set the `SWTBOT_KEYBOARD_LAYOUT` environment variable to the layout you want to select.
 For more information on SWTBot's keyboard layouts, see [Keyboard Layouts in SWTBot on the Eclipse wiki](https://wiki.eclipse.org/SWTBot/Keyboard_Layouts).

--- a/docs/dev/src/development/automated-tests/ui-integration-tests.md
+++ b/docs/dev/src/development/automated-tests/ui-integration-tests.md
@@ -1,4 +1,4 @@
-# Use interface integration tests
+# Using interface integration tests
 
 ## Adding new integration tests
 
@@ -71,8 +71,8 @@ Adding it to the feature or product is not enough.
 ## Issues with keyboard layout and integration tests
 
 Note that the SWTBot-based integration tests try to detect the keyboard layout automatically using the system locale.
-For example, `de_DE.UTF` would result in the keyboard layout `DE_DE`.
+For example, if the computer running the tests has the locale `de_DE.UTF`, SWTBot would detect the keyboard layout `DE_DE`.
 This can lead to test errors when the locale is not consistent with the keyboard layout (e.g. some programmers prefer English keyboard layouts, which would be `EN_US` or `MAC_EN_US`, while still using their native locale).
-To enforce a specific keyboard layout for the tests, set the `SWTBOT_KEYBOARD_LAYOUT` environment variable to the layout you want to select.
-This can also be helpful if SWTBot does not provide a keyboard layout for the current locale, e.g. there is **no `EN_GB` layout** but you can still enforce the very similar `EN_US` layout.
+To enforce a specific keyboard layout for the tests, set the `SWTBOT_KEYBOARD_LAYOUT` environment variable to the layout you want to use.
+This can also be helpful if SWTBot does not provide a keyboard layout for the current locale, e.g., if there is no `EN_GB` layout you can still enforce the very similar `EN_US` layout.
 For more information on SWTBot's keyboard layouts, see [Keyboard Layouts in SWTBot on the Eclipse wiki](https://wiki.eclipse.org/SWTBot/Keyboard_Layouts).

--- a/tests/org.corpus_tools.hexatomic.it.tests/META-INF/MANIFEST.MF
+++ b/tests/org.corpus_tools.hexatomic.it.tests/META-INF/MANIFEST.MF
@@ -26,7 +26,8 @@ Require-Bundle: org.junit,
  org.eclipse.e4.core.di;bundle-version="1.7.500",
  org.corpus_tools.hexatomic.grid;bundle-version="0.4.0",
  org.eclipse.nebula.widgets.nattable.core,
- org.eclipse.swtbot.nebula.nattable.finder;bundle-version="2.8.0"
+ org.eclipse.swtbot.nebula.nattable.finder;bundle-version="2.8.0",
+ org.slf4j.api
 Export-Package: org.corpus_tools.hexatomic.it.tests
 Bundle-Activator: org.corpus_tools.hexatomic.it.tests.Activator
 Bundle-ActivationPolicy: lazy

--- a/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestGraphEditor.java
+++ b/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestGraphEditor.java
@@ -29,6 +29,7 @@ import org.eclipse.e4.core.contexts.ContextInjectionFactory;
 import org.eclipse.e4.core.contexts.IEclipseContext;
 import org.eclipse.e4.ui.workbench.modeling.EPartService;
 import org.eclipse.emf.common.util.URI;
+import org.eclipse.jface.bindings.keys.KeyStroke;
 import org.eclipse.swt.SWT;
 import org.eclipse.swtbot.e4.finder.widgets.SWTBotView;
 import org.eclipse.swtbot.e4.finder.widgets.SWTWorkbenchBot;
@@ -36,6 +37,7 @@ import org.eclipse.swtbot.swt.finder.keyboard.Keyboard;
 import org.eclipse.swtbot.swt.finder.keyboard.KeyboardFactory;
 import org.eclipse.swtbot.swt.finder.keyboard.Keystrokes;
 import org.eclipse.swtbot.swt.finder.utils.SWTUtils;
+import org.eclipse.swtbot.swt.finder.utils.WidgetTextDescription;
 import org.eclipse.swtbot.swt.finder.waits.DefaultCondition;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotCheckBox;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotStyledText;
@@ -66,7 +68,7 @@ class TestGraphEditor {
   private ErrorService errorService;
   private ProjectManager projectManager;
 
-  private final Keyboard keyboard = KeyboardFactory.getSWTKeyboard();
+  private final Keyboard keyboard = KeyboardFactory.getAWTKeyboard();
 
   private final class GraphLoadedCondition extends DefaultCondition {
 
@@ -146,8 +148,6 @@ class TestGraphEditor {
 
   @BeforeEach
   void setup() {
-    org.eclipse.swtbot.swt.finder.utils.SWTBotPreferences.KEYBOARD_STRATEGY =
-        "org.eclipse.swtbot.swt.finder.keyboard.SWTKeyboardStrategy";
     TestHelper.setKeyboardLayout();
 
     IEclipseContext ctx = TestHelper.getEclipseContext();
@@ -274,7 +274,11 @@ class TestGraphEditor {
         new ViewLocationReachedCondition(viewPort, new Point(origLocation.x, origLocation.y)));
 
     // Zoom in so we can move the view with the arrow keys
-    keyboard.pressShortcut(SWT.CTRL, '+');
+    // Use the mock keyboard for this since AWT/SWT keyboards don't map the keypad keys yet.
+    Keyboard mockKeyboadForGraph =
+        KeyboardFactory.getMockKeyboard(g, new WidgetTextDescription(g));
+    KeyStroke[] strokesZoomIn = {Keystrokes.CTRL, KeyStroke.getInstance(0, SWT.KEYPAD_ADD)};
+    mockKeyboadForGraph.pressShortcut(strokesZoomIn);
 
     origLocation = (Point) SWTUtils.invokeMethod(viewPort, GET_VIEW_LOCATION);
 
@@ -320,7 +324,8 @@ class TestGraphEditor {
         new ViewLocationReachedCondition(viewPort, new Point(origLocation.x, origLocation.y)));
 
     // Zoom out again: moving up should not have any effect again
-    keyboard.pressShortcut(SWT.CTRL, '-');
+    KeyStroke[] strokesZoomOut = {Keystrokes.CTRL, KeyStroke.getInstance(0, SWT.KEYPAD_SUBTRACT)};
+    mockKeyboadForGraph.pressShortcut(strokesZoomOut);
     origLocation = (Point) SWTUtils.invokeMethod(viewPort, GET_VIEW_LOCATION);
     keyboard.pressShortcut(Keystrokes.DOWN);
     bot.waitUntil(

--- a/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestHelper.java
+++ b/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestHelper.java
@@ -38,7 +38,7 @@ public class TestHelper {
   }
 
   /**
-   * Checks if the {{@link #SWTBOT_KEYBOARD_LAYOUT} environment variable is set and update the
+   * Checks if the {{@link #SWTBOT_KEYBOARD_LAYOUT} environment variable is set and updates the
    * keyboard layout accordingly.
    */
   public static void setKeyboardLayout() {

--- a/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestHelper.java
+++ b/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestHelper.java
@@ -16,6 +16,10 @@ import org.osgi.framework.FrameworkUtil;
  */
 public class TestHelper {
 
+  private static final String SWTBOT_KEYBOARD_LAYOUT = "SWTBOT_KEYBOARD_LAYOUT";
+  private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(TestHelper.class);
+
+
   private TestHelper() {
     // Hide default constructor
   }
@@ -34,10 +38,22 @@ public class TestHelper {
   }
 
   /**
-   * Sets the SWTBot keyboard layout to <code>EN_US</code>.
+   * Checks if the {{@link #SWTBOT_KEYBOARD_LAYOUT} environment variable is set and update the
+   * keyboard layout accordingly.
    */
   public static void setKeyboardLayout() {
-    org.eclipse.swtbot.swt.finder.utils.SWTBotPreferences.KEYBOARD_LAYOUT = "EN_US";
+    try {
+      String forcedKeyboardLayout = System.getenv(SWTBOT_KEYBOARD_LAYOUT);
+      if (forcedKeyboardLayout != null) {
+        org.eclipse.swtbot.swt.finder.utils.SWTBotPreferences.KEYBOARD_LAYOUT =
+            forcedKeyboardLayout;
+      }
+    } catch (SecurityException ex) {
+      log.error(
+          "Could not get environment variable " + SWTBOT_KEYBOARD_LAYOUT
+              + " because the security mananger is running and disallowed access",
+          ex);
+    }
   }
 
 }


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help. -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] The *Unreleased* section in CHANGELOG.md has been amended to reflect the changes in this PR
- [X] Build (`mvn verify`) was run locally and any changes were pushed
- [X] The pull request is against the correct branch (`master` for bug fixes, `develop` for new functionality)


## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The GraphEditor test fails when trying to zoom in.

Issue Number: fixes #202 and provides an alternative fix for #127 (since #192 is partly reverted)


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Use the automatically detected keyboard layout for UI integration tests
- Allow to overwrite this with the SWTBOT_KEYBOARD_LAYOUT if necesary
- In addition to zooming in and out with <kbd>Ctrk</kbd>+<kbd>+</kbd>/<kbd>-</kbd> allow to use the <kbd>+</kbd> and <kbd>-</kbd> key of the keypad (<kbd>Ctrl</kbd> still needs to be pressed). This allows to make the test more locale independent and has the added benefit that a user with a keypad an US keyboard layout needs to press a key less.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Does this introduce new dependencies?

- [ ] Yes
- [X] No

If this introduces new dependencies:

- [ ] [Dependencies and citation templates](https://github.com/hexatomic/hexatomic/tree/develop/releng/templates) have been updated where necessary

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

# Checklist for maintainers

## Releases

- [ ] Do **NOT** push the green merge button on GitHub.  
Follow the latest version of the [developer/maintainer docs](https://hexatomic.github.io/hexatomic/dev/) for making releases.
- [ ] License and citation information for dependencies are complete (each dependency has a folder in `/THIRD-PARTY/`).