### PR TITLE
Fix potential bugs reported by SonarCloud (hotfix release)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.3] - 2020-09-04
+
 ### Fixed
 
 - Several potential bugs (e.g. null pointer exceptions) reported by static code analysis
@@ -94,7 +96,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.0] - 2019-11-01
 
 - This is the first public preview release of the Hexatomic developer platform.
-[Unreleased]: https://github.com/hexatomic/hexatomic/compare/v0.4.2...HEAD
+[Unreleased]: https://github.com/hexatomic/hexatomic/compare/v0.4.3...HEAD
+[0.4.3]: https://github.com/hexatomic/hexatomic/compare/v0.4.2...v0.4.3
 [0.4.2]: https://github.com/hexatomic/hexatomic/compare/v0.4.1...v0.4.2
 [0.4.1]: https://github.com/hexatomic/hexatomic/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/hexatomic/hexatomic/compare/v0.3.1...v0.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Several potential bugs (e.g. null pointer exceptions) reported by static code analysis
+
 ## [0.4.2] - 2020-08-11
 
 ### Fixed

--- a/bundles/org.corpus_tools.hexatomic.core/META-INF/MANIFEST.MF
+++ b/bundles/org.corpus_tools.hexatomic.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Hexatomic Core Plugin
 Bundle-SymbolicName: org.corpus_tools.hexatomic.core;singleton:=true
-Bundle-Version: 0.4.2
+Bundle-Version: 0.4.3
 Bundle-Vendor: Hexatomic Research Project
 Require-Bundle: javax.inject;bundle-version="0.0.0",
  org.eclipse.core.runtime;bundle-version="0.0.0",

--- a/bundles/org.corpus_tools.hexatomic.core/src/main/java/org/corpus_tools/hexatomic/core/ProjectManager.java
+++ b/bundles/org.corpus_tools.hexatomic.core/src/main/java/org/corpus_tools/hexatomic/core/ProjectManager.java
@@ -403,7 +403,7 @@ public class ProjectManager {
         }
       };
 
-      ProgressMonitorDialog dialog = new ProgressMonitorDialog(shell);
+      ProgressMonitorDialog dialog = createProgressMonitorDialog(shell);
 
       dialog.setCancelable(true);
       try {
@@ -417,6 +417,18 @@ public class ProjectManager {
         Thread.currentThread().interrupt();
       }
     }
+  }
+
+
+  /**
+   * Helper method to create a new progress monitor.
+   * This is a method so it can be overwritten by other implementations.
+   * 
+   * @param shell A SWT shell.
+   * @return The newly created progress monitor.
+   */
+  public ProgressMonitorDialog createProgressMonitorDialog(Shell shell) {
+    return new ProgressMonitorDialog(shell);
   }
 
 

--- a/bundles/org.corpus_tools.hexatomic.core/src/main/java/org/corpus_tools/hexatomic/core/ProjectManager.java
+++ b/bundles/org.corpus_tools.hexatomic.core/src/main/java/org/corpus_tools/hexatomic/core/ProjectManager.java
@@ -414,8 +414,13 @@ public class ProjectManager {
       dialog.setCancelable(true);
       try {
         dialog.run(true, true, operation);
-      } catch (InvocationTargetException | InterruptedException ex) {
+      } catch (InvocationTargetException ex) {
         errorService.handleException("Could not save project", ex, ProjectManager.class);
+      } catch (InterruptedException ex) {
+        errorService.handleException("Could not save project because thread was interrupted", ex,
+            ProjectManager.class);
+        // Re-interrupt thread to restore the interrupted state
+        Thread.currentThread().interrupt();
       }
     }
   }

--- a/bundles/org.corpus_tools.hexatomic.core/src/main/java/org/corpus_tools/hexatomic/core/ProjectManager.java
+++ b/bundles/org.corpus_tools.hexatomic.core/src/main/java/org/corpus_tools/hexatomic/core/ProjectManager.java
@@ -92,16 +92,10 @@ public class ProjectManager {
   @Inject
   UISynchronize sync;
 
-  private SaltNotificationFactory notificationFactory;
-
   private final Set<Listener> allListeners = new LinkedHashSet<>();
   private boolean listenersActive = true;
 
   private boolean hasUnsavedChanges;
-
-  public ProjectManager() {
-
-  }
 
   @PostConstruct
   void postConstruct() {
@@ -113,7 +107,7 @@ public class ProjectManager {
     this.hasUnsavedChanges = false;
 
     // Allow to register a change listener with Salt
-    notificationFactory = new SaltNotificationFactory();
+    SaltNotificationFactory notificationFactory = new SaltNotificationFactory();
     SaltFactory.setFactory(notificationFactory);
     notificationFactory.addListener(new ProxyListener());
 

--- a/bundles/org.corpus_tools.hexatomic.core/src/main/java/org/corpus_tools/hexatomic/core/errors/ErrorService.java
+++ b/bundles/org.corpus_tools.hexatomic.core/src/main/java/org/corpus_tools/hexatomic/core/errors/ErrorService.java
@@ -181,7 +181,7 @@ public class ErrorService {
     }
 
     return new MultiStatus(bundleID, IStatus.ERROR, children.toArray(new Status[] {}),
-        ex.toString(), ex);
+        message, ex);
 
   }
 

--- a/bundles/org.corpus_tools.hexatomic.core/src/main/java/org/corpus_tools/hexatomic/core/errors/ErrorService.java
+++ b/bundles/org.corpus_tools.hexatomic.core/src/main/java/org/corpus_tools/hexatomic/core/errors/ErrorService.java
@@ -140,7 +140,7 @@ public class ErrorService {
    * {@link #handleException(String, Throwable, Class)}.
    * 
    * <p>
-   * This property can be used to check in unit tests if any error has occured and was handled in
+   * This property can be used to check in unit tests if any error has occurred and was handled in
    * the UI.
    * </p>
    * 
@@ -148,6 +148,16 @@ public class ErrorService {
    */
   public Optional<IStatus> getLastException() {
     return lastException;
+  }
+
+  /**
+   * Clear the last exception that has been handled with
+   * {@link #handleException(String, Throwable, Class)}. This means calls to
+   * {@link #getLastException()} will return an empty value.
+   * 
+   */
+  public void clearLastException() {
+    lastException = Optional.empty();
   }
 
   /**

--- a/bundles/org.corpus_tools.hexatomic.core/src/main/java/org/corpus_tools/hexatomic/core/errors/ErrorService.java
+++ b/bundles/org.corpus_tools.hexatomic.core/src/main/java/org/corpus_tools/hexatomic/core/errors/ErrorService.java
@@ -78,9 +78,9 @@ public class ErrorService {
     String bundleID = getBundleID(triggeringClass);
 
     IStatus status = createStatusFromException(message, bundleID, ex);
-    lastException = Optional.of(status);
 
     sync.syncExec(() -> {
+      lastException = Optional.of(status);
       ErrorDialog.openError(null, ERROR_OCCURED_MSG, message, status);
     });
 
@@ -124,7 +124,7 @@ public class ErrorService {
    * @param context Class to get the bundle for
    * @return The bundle ID or "unknown" if unable to get the actual ID.
    */
-  private String getBundleID(Class<?> context) {
+  private static String getBundleID(Class<?> context) {
     String bundleID = "unknown";
     if (context != null) {
       Bundle bundle = FrameworkUtil.getBundle(context);
@@ -157,7 +157,9 @@ public class ErrorService {
    * 
    */
   public void clearLastException() {
-    lastException = Optional.empty();
+    sync.syncExec(() -> {
+      lastException = Optional.empty();
+    });
   }
 
   /**
@@ -168,7 +170,8 @@ public class ErrorService {
    * @param ex The exception to create the status from.
    * @return A status with the stack-trace and the message.
    */
-  private MultiStatus createStatusFromException(String message, String bundleID, Throwable ex) {
+  private static MultiStatus createStatusFromException(String message, String bundleID,
+      Throwable ex) {
     List<Status> children = new ArrayList<>();
     StackTraceElement[] stackTrace = ex.getStackTrace();
 

--- a/bundles/org.corpus_tools.hexatomic.core/src/main/java/org/corpus_tools/hexatomic/core/handlers/SaveAsHandler.java
+++ b/bundles/org.corpus_tools.hexatomic.core/src/main/java/org/corpus_tools/hexatomic/core/handlers/SaveAsHandler.java
@@ -60,10 +60,11 @@ public class SaveAsHandler {
     if (location == null) {
       DirectoryDialog dialog = new DirectoryDialog(shell);
 
-      if (lastPath == null && projectManager.getLocation().isPresent()) {
+      java.util.Optional<URI> originalLocation = projectManager.getLocation();
+      if (lastPath == null && originalLocation.isPresent()) {
         // The user did not specifically selected a path to save yet, but we can use the original
         // path from where the corpus was loaded.
-        lastPath = projectManager.getLocation().get().toFileString();
+        lastPath = originalLocation.get().toFileString();
       }
 
       if (lastPath != null) {

--- a/bundles/org.corpus_tools.hexatomic.core/src/main/java/org/corpus_tools/hexatomic/core/handlers/SaveAsHandler.java
+++ b/bundles/org.corpus_tools.hexatomic.core/src/main/java/org/corpus_tools/hexatomic/core/handlers/SaveAsHandler.java
@@ -44,6 +44,8 @@ public class SaveAsHandler {
 
   private String lastPath;
 
+  private DirectoryDialog dialog;
+
 
   /**
    * Saves the Salt project and all opened documents.
@@ -58,7 +60,9 @@ public class SaveAsHandler {
 
     String resultPath;
     if (location == null) {
-      DirectoryDialog dialog = new DirectoryDialog(shell);
+      if (dialog == null) {
+        dialog = new DirectoryDialog(shell);
+      }
 
       java.util.Optional<URI> originalLocation = projectManager.getLocation();
       if (lastPath == null && originalLocation.isPresent()) {
@@ -86,5 +90,13 @@ public class SaveAsHandler {
   @CanExecute
   public boolean canExecute() {
     return projectManager.isDirty() || projectManager.getLocation().isPresent();
+  }
+
+  public void setProjectManager(ProjectManager projectManager) {
+    this.projectManager = projectManager;
+  }
+
+  public void setDialog(DirectoryDialog dialog) {
+    this.dialog = dialog;
   }
 }

--- a/bundles/org.corpus_tools.hexatomic.core/src/main/java/org/corpus_tools/hexatomic/core/handlers/SaveAsHandler.java
+++ b/bundles/org.corpus_tools.hexatomic.core/src/main/java/org/corpus_tools/hexatomic/core/handlers/SaveAsHandler.java
@@ -44,9 +44,6 @@ public class SaveAsHandler {
 
   private String lastPath;
 
-  private DirectoryDialog dialog;
-
-
   /**
    * Saves the Salt project and all opened documents.
    * 
@@ -60,10 +57,6 @@ public class SaveAsHandler {
 
     String resultPath;
     if (location == null) {
-      if (dialog == null) {
-        dialog = new DirectoryDialog(shell);
-      }
-
       java.util.Optional<URI> originalLocation = projectManager.getLocation();
       if (lastPath == null && originalLocation.isPresent()) {
         // The user did not specifically selected a path to save yet, but we can use the original
@@ -71,6 +64,7 @@ public class SaveAsHandler {
         lastPath = originalLocation.get().toFileString();
       }
 
+      DirectoryDialog dialog = createDialog(shell);
       if (lastPath != null) {
         dialog.setFilterPath(lastPath);
       }
@@ -96,7 +90,7 @@ public class SaveAsHandler {
     this.projectManager = projectManager;
   }
 
-  public void setDialog(DirectoryDialog dialog) {
-    this.dialog = dialog;
+  protected DirectoryDialog createDialog(Shell shell) {
+    return new DirectoryDialog(shell);
   }
 }

--- a/bundles/org.corpus_tools.hexatomic.corpusedit/META-INF/MANIFEST.MF
+++ b/bundles/org.corpus_tools.hexatomic.corpusedit/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Corpus Structure Editor
 Bundle-SymbolicName: org.corpus_tools.hexatomic.corpusstructureeditor;singleton:=true
-Bundle-Version: 0.4.2
+Bundle-Version: 0.4.3
 Require-Bundle: javax.inject,
  org.eclipse.osgi,
  org.eclipse.jface,

--- a/bundles/org.corpus_tools.hexatomic.graph/META-INF/MANIFEST.MF
+++ b/bundles/org.corpus_tools.hexatomic.graph/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Graph Editor
 Bundle-SymbolicName: org.corpus_tools.hexatomic.graph;singleton:=true
-Bundle-Version: 0.4.2
+Bundle-Version: 0.4.3
 Require-Bundle: javax.inject,
  org.eclipse.osgi,
  org.eclipse.jface,

--- a/bundles/org.corpus_tools.hexatomic.graph/pom.xml
+++ b/bundles/org.corpus_tools.hexatomic.graph/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>org.corpus_tools.hexatomic.bundles</artifactId>
         <groupId>org.corpus_tools</groupId>
-        <version>0.4.2</version>
+        <version>0.4.3</version>
     </parent>
 
 

--- a/bundles/org.corpus_tools.hexatomic.grid/META-INF/MANIFEST.MF
+++ b/bundles/org.corpus_tools.hexatomic.grid/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Hexatomic Grid Editor
 Bundle-SymbolicName: org.corpus_tools.hexatomic.grid;singleton:=true
-Bundle-Version: 0.4.2
+Bundle-Version: 0.4.3
 Bundle-Vendor: Hexatomic Research Project
 Require-Bundle: javax.inject,
  org.corpus_tools.hexatomic.core;bundle-version="0.4.0",

--- a/bundles/org.corpus_tools.hexatomic.grid/src/main/java/org/corpus_tools/hexatomic/grid/GridEditor.java
+++ b/bundles/org.corpus_tools.hexatomic.grid/src/main/java/org/corpus_tools/hexatomic/grid/GridEditor.java
@@ -112,7 +112,9 @@ public class GridEditor {
   public void postConstruct(Composite parent) {
     this.graph = getGraph();
     bodyDataProvider.setGraph(graph);
-    log.debug("Starting Grid Editor for document '{}'.", graph.getDocument().getName());
+    if (graph != null && graph.getDocument() != null) {
+      log.debug("Starting Grid Editor for document '{}'.", graph.getDocument().getName());
+    }
 
     parent.setLayout(new GridLayout());
 

--- a/bundles/org.corpus_tools.hexatomic.textviewer/META-INF/MANIFEST.MF
+++ b/bundles/org.corpus_tools.hexatomic.textviewer/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.corpus_tools.hexatomic.textviewer
 Bundle-SymbolicName: org.corpus_tools.hexatomic.textviewer;singleton:=true
-Bundle-Version: 0.4.2
+Bundle-Version: 0.4.3
 Require-Bundle: javax.inject,
  org.eclipse.osgi,
  org.eclipse.jface,

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.corpus_tools</groupId>
 		<artifactId>org.corpus_tools.hexatomic.root</artifactId>
-		<version>0.4.2</version>
+		<version>0.4.3</version>
 	</parent>
 	
 	<properties>

--- a/features/org.corpus_tools.hexatomic/feature.xml
+++ b/features/org.corpus_tools.hexatomic/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.corpus_tools.hexatomic"
       label="Hexatomic Core Feature"
-      version="0.4.2"
+      version="0.4.3"
       provider-name="Hexatomic Research Project">
 
    <description url="http://www.example.com/description">

--- a/features/org.corpus_tools.hexatomic/pom.xml
+++ b/features/org.corpus_tools.hexatomic/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.corpus_tools</groupId>
         <artifactId>org.corpus_tools.hexatomic.features</artifactId>
-        <version>0.4.2</version>
+        <version>0.4.3</version>
     </parent>
 
     <build>

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.corpus_tools</groupId>
         <artifactId>org.corpus_tools.hexatomic.root</artifactId>
-        <version>0.4.2</version>
+        <version>0.4.3</version>
     </parent>
     <modules>
         <module>org.corpus_tools.hexatomic</module>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.corpus_tools</groupId>
 	<artifactId>org.corpus_tools.hexatomic.root</artifactId>
-	<version>0.4.2</version>
+	<version>0.4.3</version>
 	<packaging>pom</packaging>
 	<!-- SCM -->
 	<scm>
@@ -151,7 +151,7 @@
 						<artifact>
 							<groupId>org.corpus_tools</groupId>
 							<artifactId>org.corpus_tools.hexatomic.target</artifactId>
-							<version>0.4.2</version>
+							<version>0.4.3</version>
 						</artifact>
 					</target>
 					<environments>

--- a/releng/org.corpus_tools.hexatomic.product/pom.xml
+++ b/releng/org.corpus_tools.hexatomic.product/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.corpus_tools</groupId>
     <artifactId>org.corpus_tools.hexatomic.releng</artifactId>
-    <version>0.4.2</version>
+    <version>0.4.3</version>
   </parent>
   <artifactId>org.corpus_tools.hexatomic.product</artifactId>
   <packaging>eclipse-repository</packaging>

--- a/releng/org.corpus_tools.hexatomic.target/pom.xml
+++ b/releng/org.corpus_tools.hexatomic.target/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.corpus_tools</groupId>
         <artifactId>org.corpus_tools.hexatomic.releng</artifactId>
-        <version>0.4.2</version>
+        <version>0.4.3</version>
     </parent>
     <artifactId>org.corpus_tools.hexatomic.target</artifactId>
     <packaging>eclipse-target-definition</packaging>

--- a/releng/org.corpus_tools.hexatomic.update/pom.xml
+++ b/releng/org.corpus_tools.hexatomic.update/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.corpus_tools</groupId>
         <artifactId>org.corpus_tools.hexatomic.releng</artifactId>
-        <version>0.4.2</version>
+        <version>0.4.3</version>
     </parent>
     <artifactId>org.corpus_tools.hexatomic.update</artifactId>
     <packaging>eclipse-repository</packaging>

--- a/releng/pom.xml
+++ b/releng/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.corpus_tools</groupId>
         <artifactId>org.corpus_tools.hexatomic.root</artifactId>
-        <version>0.4.2</version>
+        <version>0.4.3</version>
     </parent>
     <modules>
         <module>org.corpus_tools.hexatomic.update</module>

--- a/tests/org.corpus_tools.hexatomic.core.tests/META-INF/MANIFEST.MF
+++ b/tests/org.corpus_tools.hexatomic.core.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Hexatomic Core Tests
 Bundle-SymbolicName: org.corpus_tools.hexatomic.core.tests
-Bundle-Version: 0.4.2
+Bundle-Version: 0.4.3
 Fragment-Host: org.corpus_tools.hexatomic.core;bundle-version="0.2.0"
 Automatic-Module-Name: org.corpus_tools.hexatomic.core.tests
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/tests/org.corpus_tools.hexatomic.core.tests/src/main/java/org/corpus_tools/hexatomic/core/TestProjectManager.java
+++ b/tests/org.corpus_tools.hexatomic.core.tests/src/main/java/org/corpus_tools/hexatomic/core/TestProjectManager.java
@@ -103,41 +103,42 @@ class TestProjectManager {
     // Load document once
     Optional<SDocument> document = projectManager.getDocument(documentID, true);
     assertTrue(document.isPresent());
-    assertNotNull(document.get().getDocumentGraphLocation());
-    assertNotNull(document.get().getDocumentGraph());
+    if (document.isPresent()) {
+      assertNotNull(document.get().getDocumentGraphLocation());
+      assertNotNull(document.get().getDocumentGraph());
 
-    // Mock three open documents: two of them are the same
-    Map<String, String> state1 = new HashMap<>();
-    state1.put(DOCUMENT_ID, documentID);
+      // Mock three open documents: two of them are the same
+      Map<String, String> state1 = new HashMap<>();
+      state1.put(DOCUMENT_ID, documentID);
 
-    Map<String, String> state2 = new HashMap<>();
-    state2.put(DOCUMENT_ID, "salt:/rootCorpus/subCorpus2/doc4");
+      Map<String, String> state2 = new HashMap<>();
+      state2.put(DOCUMENT_ID, "salt:/rootCorpus/subCorpus2/doc4");
 
-    Map<String, String> state3 = new HashMap<>();
-    state3.put(DOCUMENT_ID, documentID);
+      Map<String, String> state3 = new HashMap<>();
+      state3.put(DOCUMENT_ID, documentID);
 
-    MPart editor1 = mock(MPart.class);
-    MPart editor2 = mock(MPart.class);
-    MPart editor3 = mock(MPart.class);
+      MPart editor1 = mock(MPart.class);
+      MPart editor2 = mock(MPart.class);
+      MPart editor3 = mock(MPart.class);
 
-    when(editor1.getPersistedState()).thenReturn(state1);
-    when(editor2.getPersistedState()).thenReturn(state2);
-    when(editor3.getPersistedState()).thenReturn(state3);
+      when(editor1.getPersistedState()).thenReturn(state1);
+      when(editor2.getPersistedState()).thenReturn(state2);
+      when(editor3.getPersistedState()).thenReturn(state3);
 
-    when(partService.getParts()).thenReturn(Arrays.asList(editor1, editor2, editor3));
+      when(partService.getParts()).thenReturn(Arrays.asList(editor1, editor2, editor3));
 
-    // Notify one of the documents was closed
-    projectManager.unloadDocumentGraphWhenClosed(documentID);
-    // Document must still be loaded in memory
-    assertNotNull(document.get().getDocumentGraph());
+      // Notify one of the documents was closed
+      projectManager.unloadDocumentGraphWhenClosed(documentID);
+      // Document must still be loaded in memory
+      assertNotNull(document.get().getDocumentGraph());
 
-    // Remove the one of the closed parts
-    when(partService.getParts()).thenReturn(Arrays.asList(editor2, editor3));
-    // Notify about closing one of the documents again
-    projectManager.unloadDocumentGraphWhenClosed(documentID);
-    // Document should have been unloaded from memory
-    assertNull(document.get().getDocumentGraph());
+      // Remove the one of the closed parts
+      when(partService.getParts()).thenReturn(Arrays.asList(editor2, editor3));
+      // Notify about closing one of the documents again
+      projectManager.unloadDocumentGraphWhenClosed(documentID);
+      // Document should have been unloaded from memory
+      assertNull(document.get().getDocumentGraph());
+    }
   }
-
 
 }

--- a/tests/org.corpus_tools.hexatomic.core.tests/src/main/java/org/corpus_tools/hexatomic/core/handler/TestSaveAsHandler.java
+++ b/tests/org.corpus_tools.hexatomic.core.tests/src/main/java/org/corpus_tools/hexatomic/core/handler/TestSaveAsHandler.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test;
 
 public class TestSaveAsHandler {
 
+
   private SaveAsHandler fixture;
   private URI exampleProjectUri;
   private Shell shell;
@@ -28,7 +29,7 @@ public class TestSaveAsHandler {
 
   @BeforeEach
   private void setUp() {
-    this.fixture = new SaveAsHandler();
+    this.fixture = new CustomSaveAsHandler();
     File exampleProjectDirectory =
         new File("src/main/resources/org/corpus_tools/hexatomic/core/example-corpus/");
     assertTrue(exampleProjectDirectory.isDirectory());
@@ -40,7 +41,6 @@ public class TestSaveAsHandler {
     
     dialog = mock(DirectoryDialog.class);
     
-    this.fixture.setDialog(dialog);
     this.fixture.setProjectManager(projectManager);
 
   }
@@ -77,4 +77,18 @@ public class TestSaveAsHandler {
     verifyNoMoreInteractions(dialog);
     verifyNoMoreInteractions(projectManager);
   }
+
+  /**
+   * An implementation that returns the mock dialog instead of a real one.
+   * 
+   * @author Thomas Krause
+   *
+   */
+  private class CustomSaveAsHandler extends SaveAsHandler {
+    @Override
+    protected DirectoryDialog createDialog(Shell shell) {
+      return dialog;
+    }
+  }
+
 }

--- a/tests/org.corpus_tools.hexatomic.core.tests/src/main/java/org/corpus_tools/hexatomic/core/handler/TestSaveAsHandler.java
+++ b/tests/org.corpus_tools.hexatomic.core.tests/src/main/java/org/corpus_tools/hexatomic/core/handler/TestSaveAsHandler.java
@@ -27,7 +27,7 @@ public class TestSaveAsHandler {
 
 
   @BeforeEach
-  public void setUp() throws Exception {
+  private void setUp() throws Exception {
     this.fixture = new SaveAsHandler();
     File exampleProjectDirectory =
         new File("src/main/resources/org/corpus_tools/hexatomic/core/example-corpus/");

--- a/tests/org.corpus_tools.hexatomic.core.tests/src/main/java/org/corpus_tools/hexatomic/core/handler/TestSaveAsHandler.java
+++ b/tests/org.corpus_tools.hexatomic.core.tests/src/main/java/org/corpus_tools/hexatomic/core/handler/TestSaveAsHandler.java
@@ -1,0 +1,80 @@
+package org.corpus_tools.hexatomic.core.handler;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.util.Optional;
+import org.corpus_tools.hexatomic.core.ProjectManager;
+import org.corpus_tools.hexatomic.core.handlers.SaveAsHandler;
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.swt.widgets.DirectoryDialog;
+import org.eclipse.swt.widgets.Shell;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class TestSaveAsHandler {
+
+  private SaveAsHandler fixture;
+  private URI exampleProjectUri;
+  private Shell shell;
+  private ProjectManager projectManager;
+  private DirectoryDialog dialog;
+
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    this.fixture = new SaveAsHandler();
+    File exampleProjectDirectory =
+        new File("src/main/resources/org/corpus_tools/hexatomic/core/example-corpus/");
+    assertTrue(exampleProjectDirectory.isDirectory());
+
+    exampleProjectUri = URI.createFileURI(exampleProjectDirectory.getAbsolutePath());
+
+    shell = mock(Shell.class);
+    projectManager = mock(ProjectManager.class);
+    
+    dialog = mock(DirectoryDialog.class);
+    
+    this.fixture.setDialog(dialog);
+    this.fixture.setProjectManager(projectManager);
+
+  }
+
+  @Test
+  public void testSaveAsOriginalLocation() {
+    when(projectManager.getLocation()).thenReturn(Optional.of(exampleProjectUri));
+    when(dialog.open()).thenReturn(exampleProjectUri.toFileString());
+    
+    this.fixture.execute(shell, null);
+    
+    // This command needs to open a dialog with the last path as initial location
+    verify(projectManager).getLocation();
+    verify(dialog).setFilterPath(eq(exampleProjectUri.toFileString()));
+    verify(dialog).open();
+    verify(projectManager).saveTo(eq(exampleProjectUri), eq(shell));
+
+    verifyNoMoreInteractions(dialog);
+    verifyNoMoreInteractions(projectManager);
+  }
+
+  @Test
+  public void testSaveAsNoOriginalLocation() {
+    when(projectManager.getLocation()).thenReturn(Optional.empty());
+    when(dialog.open()).thenReturn(exampleProjectUri.toFileString());
+
+    this.fixture.execute(shell, null);
+
+    // This command needs to open a dialog with the last path but can't select any previous location
+    verify(projectManager).getLocation();
+    verify(dialog).open();
+    verify(projectManager).saveTo(eq(exampleProjectUri), eq(shell));
+
+    verifyNoMoreInteractions(dialog);
+    verifyNoMoreInteractions(projectManager);
+  }
+}

--- a/tests/org.corpus_tools.hexatomic.core.tests/src/main/java/org/corpus_tools/hexatomic/core/handler/TestSaveAsHandler.java
+++ b/tests/org.corpus_tools.hexatomic.core.tests/src/main/java/org/corpus_tools/hexatomic/core/handler/TestSaveAsHandler.java
@@ -27,7 +27,7 @@ public class TestSaveAsHandler {
 
 
   @BeforeEach
-  private void setUp() throws Exception {
+  private void setUp() {
     this.fixture = new SaveAsHandler();
     File exampleProjectDirectory =
         new File("src/main/resources/org/corpus_tools/hexatomic/core/example-corpus/");

--- a/tests/org.corpus_tools.hexatomic.graph.tests/META-INF/MANIFEST.MF
+++ b/tests/org.corpus_tools.hexatomic.graph.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Graph Tests
 Bundle-SymbolicName: org.corpus_tools.hexatomic.graph.tests
-Bundle-Version: 0.4.2
+Bundle-Version: 0.4.3
 Fragment-Host: org.corpus_tools.hexatomic.graph;bundle-version="0.4.0"
 Automatic-Module-Name: org.corpus_tools.hexatomic.graph.tests
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/tests/org.corpus_tools.hexatomic.grid.tests/META-INF/MANIFEST.MF
+++ b/tests/org.corpus_tools.hexatomic.grid.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Grid Editor Tests
 Bundle-SymbolicName: org.corpus_tools.hexatomic.grid.tests
-Bundle-Version: 0.4.2
+Bundle-Version: 0.4.3
 Bundle-Vendor: Hexatomic Research Project
 Fragment-Host: org.corpus_tools.hexatomic.grid;bundle-version="0.4.0"
 Automatic-Module-Name: org.corpus_tools.hexatomic.grid.tests

--- a/tests/org.corpus_tools.hexatomic.grid.tests/src/main/java/org/corpus_tools/hexatomic/grid/data/TestGraphDataProvider.java
+++ b/tests/org.corpus_tools.hexatomic.grid.tests/src/main/java/org/corpus_tools/hexatomic/grid/data/TestGraphDataProvider.java
@@ -370,11 +370,13 @@ class TestGraphDataProvider {
       }
     }
     assertNotNull(addedSpan);
-    assertEquals("ABC", fixture.getDataValue(4, 0));
-    assertEquals(8, overlappingExampleGraph.getSpans().size());
-    SAnnotation annotation = addedSpan.getAnnotation("five", "span_2");
-    assertNotNull(annotation);
-    assertEquals("ABC", annotation.getValue());
+    if (addedSpan != null) {
+      assertEquals("ABC", fixture.getDataValue(4, 0));
+      assertEquals(8, overlappingExampleGraph.getSpans().size());
+      SAnnotation annotation = addedSpan.getAnnotation("five", "span_2");
+      assertNotNull(annotation);
+      assertEquals("ABC", annotation.getValue());
+    }
   }
 
   @Test
@@ -398,13 +400,14 @@ class TestGraphDataProvider {
       }
     }
     assertNotNull(addedSpan);
-    List<SToken> overlappedTokens = exampleGraph.getOverlappedTokens(addedSpan);
-    assertEquals(1, overlappedTokens.size());
-    assertEquals(token, overlappedTokens.get(0));
-    SAnnotation annotation = addedSpan.getAnnotation(null, "Inf-Struct");
-    assertNotNull(annotation);
-    assertEquals("ABC", annotation.getValue());
-
+    if (addedSpan != null) {
+      List<SToken> overlappedTokens = exampleGraph.getOverlappedTokens(addedSpan);
+      assertEquals(1, overlappedTokens.size());
+      assertEquals(token, overlappedTokens.get(0));
+      SAnnotation annotation = addedSpan.getAnnotation(null, "Inf-Struct");
+      assertNotNull(annotation);
+      assertEquals("ABC", annotation.getValue());
+    }
   }
 
   private SDocumentGraph retrieveGraph(String path) {

--- a/tests/org.corpus_tools.hexatomic.it.tests/META-INF/MANIFEST.MF
+++ b/tests/org.corpus_tools.hexatomic.it.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Hexatomic Integration Tests
 Bundle-SymbolicName: org.corpus_tools.hexatomic.it.tests
-Bundle-Version: 0.4.2
+Bundle-Version: 0.4.3
 Automatic-Module-Name: org.corpus_tools.hexatomic.it.tests
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.junit,

--- a/tests/org.corpus_tools.hexatomic.it.tests/META-INF/MANIFEST.MF
+++ b/tests/org.corpus_tools.hexatomic.it.tests/META-INF/MANIFEST.MF
@@ -27,7 +27,8 @@ Require-Bundle: org.junit,
  org.corpus_tools.hexatomic.grid;bundle-version="0.4.0",
  org.eclipse.nebula.widgets.nattable.core,
  org.eclipse.swtbot.nebula.nattable.finder;bundle-version="2.8.0",
- org.slf4j.api
+ org.slf4j.api,
+ org.mockito;bundle-version="2.23.0"
 Export-Package: org.corpus_tools.hexatomic.it.tests
 Bundle-Activator: org.corpus_tools.hexatomic.it.tests.Activator
 Bundle-ActivationPolicy: lazy

--- a/tests/org.corpus_tools.hexatomic.it.tests/pom.xml
+++ b/tests/org.corpus_tools.hexatomic.it.tests/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.corpus_tools</groupId>
         <artifactId>org.corpus_tools.hexatomic.tests</artifactId>
-        <version>0.4.2</version>
+        <version>0.4.3</version>
     </parent>
 
     <artifactId>org.corpus_tools.hexatomic.it.tests</artifactId>

--- a/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestCorpusStructure.java
+++ b/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestCorpusStructure.java
@@ -115,9 +115,10 @@ class TestCorpusStructure {
     assertTrue(doc1.isPresent());
     assertTrue(doc2.isPresent());
 
-    assertEquals("abc", doc1.get().getName());
-    assertEquals("def", doc2.get().getName());
-
+    if (doc1.isPresent() && doc2.isPresent()) {
+      assertEquals("abc", doc1.get().getName());
+      assertEquals("def", doc2.get().getName());
+    }
   }
 
   @Test

--- a/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestGraphEditor.java
+++ b/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestGraphEditor.java
@@ -342,30 +342,35 @@ class TestGraphEditor {
     openDefaultExample();
 
     // Get a reference to the open graph
-    SDocument doc = projectManager.getDocument("salt:/rootCorpus/subCorpus1/doc1").get();
-    SDocumentGraph graph = doc.getDocumentGraph();
+    Optional<SDocument> optionalDocument =
+        projectManager.getDocument("salt:/rootCorpus/subCorpus1/doc1");
+    assertTrue(optionalDocument.isPresent());
+    if (optionalDocument.isPresent()) {
+      SDocument doc = optionalDocument.get();
+      SDocumentGraph graph = doc.getDocumentGraph();
 
-    // Before state: no edges between the two structures
-    assertEquals(0, graph.getRelations("salt:/rootCorpus/subCorpus1/doc1#structure3",
-        "salt:/rootCorpus/subCorpus1/doc1#structure5").size());
+      // Before state: no edges between the two structures
+      assertEquals(0, graph.getRelations("salt:/rootCorpus/subCorpus1/doc1#structure3",
+          "salt:/rootCorpus/subCorpus1/doc1#structure5").size());
 
-    // Add a pointing relation between the two structures
-    enterCommand("e #structure3 -> #structure5");
+      // Add a pointing relation between the two structures
+      enterCommand("e #structure3 -> #structure5");
 
-    // Check that no exception was thrown/handled by UI
-    assertFalse(errorService.getLastException().isPresent());
+      // Check that no exception was thrown/handled by UI
+      assertFalse(errorService.getLastException().isPresent());
 
-    // Check that the edge has been added to the graph
-    List<?> rels = graph.getRelations("salt:/rootCorpus/subCorpus1/doc1#structure3",
-        "salt:/rootCorpus/subCorpus1/doc1#structure5");
-    assertEquals(1, rels.size());
-    assertTrue(rels.get(0) instanceof SPointingRelation);
+      // Check that the edge has been added to the graph
+      List<?> rels = graph.getRelations("salt:/rootCorpus/subCorpus1/doc1#structure3",
+          "salt:/rootCorpus/subCorpus1/doc1#structure5");
+      assertEquals(1, rels.size());
+      assertTrue(rels.get(0) instanceof SPointingRelation);
 
-    Graph g = bot.widget(widgetOfType(Graph.class));
-    assertNotNull(g);
+      Graph g = bot.widget(widgetOfType(Graph.class));
+      assertNotNull(g);
 
-    // Check that the edge was also added as connection in the view
-    bot.waitUntil(new NumberOfConnectionsCondition(23));
+      // Check that the edge was also added as connection in the view
+      bot.waitUntil(new NumberOfConnectionsCondition(23));
+    }
   }
 
   /**
@@ -379,45 +384,49 @@ class TestGraphEditor {
     openDefaultExample();
 
     // Get a reference to the opened document graph
-    SDocument doc = projectManager.getDocument("salt:/rootCorpus/subCorpus1/doc1").get();
-    SDocumentGraph graph = doc.getDocumentGraph();
+    Optional<SDocument> optionalDoc =
+        projectManager.getDocument("salt:/rootCorpus/subCorpus1/doc1");
+    assertTrue(optionalDoc.isPresent());
+    if (optionalDoc.isPresent()) {
+      SDocument doc = optionalDoc.get();
+      SDocumentGraph graph = doc.getDocumentGraph();
 
-    STextualDS firstText = graph.getTextualDSs().get(0);
-    final String originalText = firstText.getText();
+      STextualDS firstText = graph.getTextualDSs().get(0);
+      final String originalText = firstText.getText();
 
-    // Add an additional data source to the document graph
-    STextualDS anotherText = graph.createTextualDS("Another text");
-    graph.createToken(anotherText, 0, 7);
-    graph.createToken(anotherText, 8, 12);
+      // Add an additional data source to the document graph
+      STextualDS anotherText = graph.createTextualDS("Another text");
+      graph.createToken(anotherText, 0, 7);
+      graph.createToken(anotherText, 8, 12);
 
-    // Select the new text
-    SWTBotTable textRangeTable = bot.tableWithId("graph-editor/text-range");
-    textRangeTable.select("Another text");
+      // Select the new text
+      SWTBotTable textRangeTable = bot.tableWithId("graph-editor/text-range");
+      textRangeTable.select("Another text");
 
-    // Wait until the graph has been properly selected
-    bot.waitUntil(new DefaultCondition() {
+      // Wait until the graph has been properly selected
+      bot.waitUntil(new DefaultCondition() {
 
-      @Override
-      public boolean test() throws Exception {
-        return textRangeTable.getTableItem("Another text").isChecked();
-      }
+        @Override
+        public boolean test() throws Exception {
+          return textRangeTable.getTableItem("Another text").isChecked();
+        }
 
-      @Override
-      public String getFailureMessage() {
-        return "Second text segment was not checked";
-      }
-    }, 5000);
+        @Override
+        public String getFailureMessage() {
+          return "Second text segment was not checked";
+        }
+      }, 5000);
 
-    // Add a new tokenized text to the end
-    enterCommand("t has more tokens");
+      // Add a new tokenized text to the end
+      enterCommand("t has more tokens");
 
-    // Check that the right textual data source has been amended
-    assertEquals("Another text has more tokens", anotherText.getText());
+      // Check that the right textual data source has been amended
+      assertEquals("Another text has more tokens", anotherText.getText());
 
-    // Check the original text has not been altered and is displayed correctly
-    assertEquals(originalText, firstText.getText());
-    assertEquals(originalText, textRangeTable.cell(0, 0));
-
+      // Check the original text has not been altered and is displayed correctly
+      assertEquals(originalText, firstText.getText());
+      assertEquals(originalText, textRangeTable.cell(0, 0));
+    }
   }
 
   @Test

--- a/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestGraphEditor.java
+++ b/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestGraphEditor.java
@@ -170,12 +170,16 @@ class TestGraphEditor {
 
     exampleProjectUri = URI.createFileURI(exampleProjectDirectory.getAbsolutePath());
 
+
+    errorService.clearLastException();
+
     // Programmatically start a new salt project to get a clean state
     Map<String, String> params = new HashMap<>();
     params.put(CommandParams.FORCE_CLOSE, "true");
     ParameterizedCommand cmd = commandService
         .createCommand("org.corpus_tools.hexatomic.core.command.new_salt_project", params);
     handlerService.executeHandler(cmd);
+
   }
 
 

--- a/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestGridEditor.java
+++ b/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestGridEditor.java
@@ -12,7 +12,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import org.corpus_tools.hexatomic.core.CommandParams;
-import org.corpus_tools.hexatomic.core.errors.ErrorService;
 import org.corpus_tools.hexatomic.grid.style.StyleConfiguration;
 import org.eclipse.core.commands.ParameterizedCommand;
 import org.eclipse.e4.core.commands.ECommandService;
@@ -59,8 +58,6 @@ public class TestGridEditor {
   private EHandlerService handlerService;
   private EPartService partService;
 
-  private ErrorService errorService = new ErrorService();
-
   private final Keyboard keyboard = KeyboardFactory.getAWTKeyboard();
 
   @BeforeEach
@@ -68,8 +65,6 @@ public class TestGridEditor {
     TestHelper.setKeyboardLayout();
 
     IEclipseContext ctx = TestHelper.getEclipseContext();
-
-    ctx.set(ErrorService.class, errorService);
 
     commandService = ctx.get(ECommandService.class);
     assertNotNull(commandService);

--- a/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestProjectManager.java
+++ b/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestProjectManager.java
@@ -1,4 +1,4 @@
-package org.corpus_tools.hexatomic.core;
+package org.corpus_tools.hexatomic.it.tests;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
@@ -24,8 +24,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import org.corpus_tools.hexatomic.core.CommandParams;
+import org.corpus_tools.hexatomic.core.ProjectManager;
 import org.corpus_tools.hexatomic.core.errors.ErrorService;
-import org.corpus_tools.hexatomic.it.tests.TestHelper;
 import org.corpus_tools.salt.common.SDocument;
 import org.corpus_tools.salt.common.SDocumentGraph;
 import org.corpus_tools.salt.common.SToken;
@@ -50,7 +51,7 @@ import org.junit.jupiter.api.TestMethodOrder;
 
 @SuppressWarnings("restriction")
 @TestMethodOrder(OrderAnnotation.class)
-class TestProjectManagerIntegration {
+class TestProjectManager {
 
   private SWTWorkbenchBot bot;
 

--- a/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestProjectManager.java
+++ b/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestProjectManager.java
@@ -63,7 +63,7 @@ class TestProjectManager {
   private ErrorService errorService;
 
   @BeforeEach
-  void abc() {
+  void setup() {
     IEclipseContext ctx = TestHelper.getEclipseContext();
 
     bot = new SWTWorkbenchBot(ctx);
@@ -196,10 +196,10 @@ class TestProjectManager {
     assertFalse(errorService.getLastException().isPresent());
 
     // Use an URI which can't be saved to
-    Optional<IStatus> lastException = UIThreadRunnable.syncExec(() -> {
-      projectManager.saveTo(URI.createURI("http://localhost"), bot.getDisplay().getActiveShell());
-      return errorService.getLastException();
-    });
+    UIThreadRunnable.syncExec(() -> projectManager.saveTo(URI.createURI("http://localhost"),
+        bot.getDisplay().getActiveShell()));
+    Optional<IStatus> lastException =
+        UIThreadRunnable.syncExec(() -> errorService.getLastException());
     // Check the error has been recorded
     assertTrue(lastException.isPresent());
     if (lastException.isPresent()) {
@@ -227,12 +227,14 @@ class TestProjectManager {
 
     Path tmpDir = Files.createTempDirectory("hexatomic-project-manager-test");
 
-    Optional<IStatus> lastException = UIThreadRunnable.syncExec(() -> {
+    UIThreadRunnable.syncExec(() -> {
       // Call saveTo which should show an error
       spyingManager.saveTo(URI.createFileURI(tmpDir.toAbsolutePath().toString()),
           bot.getDisplay().getActiveShell());
-      return errorService.getLastException();
+
     });
+    Optional<IStatus> lastException =
+        UIThreadRunnable.syncExec(() -> errorService.getLastException());
     // Check the error has been recorded
     assertTrue(lastException.isPresent());
     if (lastException.isPresent()) {

--- a/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestProjectManager.java
+++ b/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestProjectManager.java
@@ -118,9 +118,14 @@ class TestProjectManager {
       // Save the project to a different location
       Path tmpDir = Files.createTempDirectory("hexatomic-project-manager-test");
 
+      // Programmatically start a new salt project to get a clean state
+      Map<String, String> params = new HashMap<>();
+      params.put(CommandParams.LOCATION, tmpDir.toString());
+      ParameterizedCommand cmd = commandService
+          .createCommand("org.corpus_tools.hexatomic.core.command.save_as_salt_project", params);
+
       UIThreadRunnable.syncExec(() -> {
-        projectManager.saveTo(URI.createFileURI(tmpDir.toString()),
-            bot.getDisplay().getActiveShell());
+        handlerService.executeHandler(cmd);
       });
 
       assertFalse(projectManager.isDirty());

--- a/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestProjectManager.java
+++ b/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestProjectManager.java
@@ -31,7 +31,6 @@ import org.eclipse.e4.core.commands.EHandlerService;
 import org.eclipse.e4.core.contexts.ContextInjectionFactory;
 import org.eclipse.e4.core.contexts.IEclipseContext;
 import org.eclipse.emf.common.util.URI;
-import org.eclipse.swtbot.e4.finder.widgets.SWTWorkbenchBot;
 import org.eclipse.swtbot.swt.finder.finders.UIThreadRunnable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
@@ -43,8 +42,6 @@ import org.junit.jupiter.api.TestMethodOrder;
 @TestMethodOrder(OrderAnnotation.class)
 class TestProjectManager {
 
-  private SWTWorkbenchBot bot;
-
   private URI exampleProjectUri;
   private ECommandService commandService;
   private EHandlerService handlerService;
@@ -54,8 +51,6 @@ class TestProjectManager {
   @BeforeEach
   void setup() {
     IEclipseContext ctx = TestHelper.getEclipseContext();
-
-    bot = new SWTWorkbenchBot(ctx);
 
     projectManager = ContextInjectionFactory.make(ProjectManager.class, ctx);
 
@@ -118,14 +113,13 @@ class TestProjectManager {
       // Save the project to a different location
       Path tmpDir = Files.createTempDirectory("hexatomic-project-manager-test");
 
-      // Programmatically start a new salt project to get a clean state
       Map<String, String> params = new HashMap<>();
       params.put(CommandParams.LOCATION, tmpDir.toString());
-      ParameterizedCommand cmd = commandService
+      final ParameterizedCommand cmdSaveAs = commandService
           .createCommand("org.corpus_tools.hexatomic.core.command.save_as_salt_project", params);
 
       UIThreadRunnable.syncExec(() -> {
-        handlerService.executeHandler(cmd);
+        handlerService.executeHandler(cmdSaveAs);
       });
 
       assertFalse(projectManager.isDirty());
@@ -154,8 +148,11 @@ class TestProjectManager {
 
         assertTrue(projectManager.isDirty());
 
+        final ParameterizedCommand cmdSave = commandService
+            .createCommand("org.corpus_tools.hexatomic.core.command.save_salt_project");
+
         UIThreadRunnable.syncExec(() -> {
-          projectManager.save(bot.getDisplay().getActiveShell());
+          handlerService.executeHandler(cmdSave);
         });
 
         assertFalse(projectManager.isDirty());

--- a/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestProjectManager.java
+++ b/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestProjectManager.java
@@ -196,11 +196,11 @@ class TestProjectManager {
     assertFalse(errorService.getLastException().isPresent());
 
     // Use an URI which can't be saved to
-    UIThreadRunnable.syncExec(() -> {
+    Optional<IStatus> lastException = UIThreadRunnable.syncExec(() -> {
       projectManager.saveTo(URI.createURI("http://localhost"), bot.getDisplay().getActiveShell());
+      return errorService.getLastException();
     });
     // Check the error has been recorded
-    Optional<IStatus> lastException = errorService.getLastException();
     assertTrue(lastException.isPresent());
     if (lastException.isPresent()) {
       assertTrue(lastException.get().getException() instanceof InvocationTargetException);
@@ -224,16 +224,16 @@ class TestProjectManager {
 
     // Check no error has been set yet
     assertFalse(errorService.getLastException().isPresent());
-    
+
     Path tmpDir = Files.createTempDirectory("hexatomic-project-manager-test");
 
-    UIThreadRunnable.syncExec(() -> {
+    Optional<IStatus> lastException = UIThreadRunnable.syncExec(() -> {
       // Call saveTo which should show an error
       spyingManager.saveTo(URI.createFileURI(tmpDir.toAbsolutePath().toString()),
           bot.getDisplay().getActiveShell());
+      return errorService.getLastException();
     });
     // Check the error has been recorded
-    Optional<IStatus> lastException = errorService.getLastException();
     assertTrue(lastException.isPresent());
     if (lastException.isPresent()) {
       assertTrue(lastException.get().getException() instanceof InterruptedException);

--- a/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestProjectManager.java
+++ b/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestProjectManager.java
@@ -170,9 +170,7 @@ class TestProjectManager {
         final ParameterizedCommand cmdSave = commandService
             .createCommand("org.corpus_tools.hexatomic.core.command.save_salt_project");
 
-        UIThreadRunnable.syncExec(() -> {
-          handlerService.executeHandler(cmdSave);
-        });
+        UIThreadRunnable.syncExec(() -> handlerService.executeHandler(cmdSave));
 
         assertFalse(projectManager.isDirty());
 

--- a/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestProjectManager.java
+++ b/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestProjectManager.java
@@ -58,7 +58,7 @@ class TestProjectManager {
   @BeforeEach
   void setup() {
     IEclipseContext ctx = TestHelper.getEclipseContext();
-    
+
     bot = new SWTWorkbenchBot(ctx);
 
     projectManager = ContextInjectionFactory.make(ProjectManager.class, ctx);
@@ -183,22 +183,21 @@ class TestProjectManager {
 
   @Test
   @Order(2)
-  public void testSaveToInvalidLocation()
-  {
-    
+  public void testSaveToInvalidLocation() {
+
     projectManager.open(exampleProjectUri);
     assertFalse(errorService.getLastException().isPresent());
 
     // Use an URI which can't be saved to
     UIThreadRunnable.syncExec(() -> {
       projectManager.saveTo(URI.createURI("http://localhost"), bot.getDisplay().getActiveShell());
+      // Check the error has been recorded
+      Optional<IStatus> lastException = errorService.getLastException();
+      assertTrue(lastException.isPresent());
+      if (lastException.isPresent()) {
+        assertTrue(lastException.get().getException() instanceof InvocationTargetException);
+      }
     });
-    // Check the error has been recorded
-    Optional<IStatus> lastException = errorService.getLastException();
-    assertTrue(lastException.isPresent());
-    if(lastException.isPresent()) {
-      assertTrue(lastException.get().getException() instanceof InvocationTargetException);
-    }
   }
 }
 

--- a/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestProjectManager.java
+++ b/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestProjectManager.java
@@ -76,6 +76,8 @@ class TestProjectManager {
 
     exampleProjectUri = URI.createFileURI(exampleProjectDirectory.getAbsolutePath());
 
+    errorService.clearLastException();
+
     // Programmatically start a new salt project to get a clean state
     Map<String, String> params = new HashMap<>();
     params.put(CommandParams.FORCE_CLOSE, "true");

--- a/tests/org.corpus_tools.hexatomic.tests.report/pom.xml
+++ b/tests/org.corpus_tools.hexatomic.tests.report/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.corpus_tools</groupId>
 		<artifactId>org.corpus_tools.hexatomic.tests</artifactId>
-		<version>0.4.2</version>
+		<version>0.4.3</version>
 	</parent>
 
 	<artifactId>org.corpus_tools.hexatomic.tests.report</artifactId>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.corpus_tools</groupId>
 		<artifactId>org.corpus_tools.hexatomic.root</artifactId>
-		<version>0.4.2</version>
+		<version>0.4.3</version>
 	</parent>
 	
 	<properties>


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help. -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 
Choose one of the following types (you can copy and paste them if you like)

- Bugfix
- Feature
- Code style update (formatting, renaming)
- Refactoring (no functional changes, no API changes)
- Build related changes
- Documentation content changes
- Other (please describe it)

--> 

Bugfix

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Static Code analysis reports 12 potential bugs, which is quite a lot for project of this size.

Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Re-interrupting thread if needed: https://sonarcloud.io/project/issues?id=hexatomic_hexatomic&open=AXJ-0KCWJ4ufXwOrU-AF&resolved=false&types=BUG
- Several cases where `isPresent()` was called on the wrong optional value (e.g. a getter function could return a different value on each call) or where it was not called at all or only using an `assertTrue()` in tests
  - https://sonarcloud.io/project/issues?id=hexatomic_hexatomic&open=AXJfW-PmFvNddLOf699i&resolved=false&types=BUG
  - https://sonarcloud.io/project/issues?id=hexatomic_hexatomic&open=AXJ-0KU0J4ufXwOrU-CE&resolved=false&types=BUG
  - https://sonarcloud.io/project/issues?id=hexatomic_hexatomic&open=AXJfW-beFvNddLOf69_H&resolved=false&types=BUG
  - https://sonarcloud.io/project/issues?id=hexatomic_hexatomic&open=AXJfW-beFvNddLOf69_G&resolved=false&types=BUG
  - https://sonarcloud.io/project/issues?id=hexatomic_hexatomic&open=AXJfW-cXFvNddLOf69_P&resolved=false&types=BUG
  - https://sonarcloud.io/project/issues?id=hexatomic_hexatomic&open=AXJfW-cXFvNddLOf69_Q&resolved=false&types=BUG
  - https://sonarcloud.io/project/issues?id=hexatomic_hexatomic&open=AXJ-0KTEJ4ufXwOrU-B9&resolved=false&types=BUG
  - https://sonarcloud.io/project/issues?id=hexatomic_hexatomic&open=AXJ-0KTEJ4ufXwOrU-B-&resolved=false&types=BUG
- Several posible null pointer exception because a nullable object is accessed without check. This also affects some tests where this would just fail the test or where there is even a `assertNotNull` before (but the static code analysis seems to need an explicit `if`)
  - https://sonarcloud.io/project/issues?id=hexatomic_hexatomic&open=AXJfW-TvFvNddLOf699-&resolved=false&types=BUG
  - https://sonarcloud.io/project/issues?id=hexatomic_hexatomic&open=AXJfW-acFvNddLOf69-4&resolved=false&types=BUG
  - https://sonarcloud.io/project/issues?id=hexatomic_hexatomic&open=AXJfW-acFvNddLOf69-5&resolved=false&types=BUG

Most of the changed code lines did not have any tests yet. I added some, but this also caused some refactoring to enable testing e.g. of the InterruptedException in `SaltProject.saveTo` which was impossible to test without mocking the created dialog.

## Does this introduce a breaking change?

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

N/A

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->


## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added **or** the PR is neither a bug fix nor a feature
- [x] Docs have been reviewed and added / updated if needed **or** the PR is neither a bug fix nor a feature
- [x] The *Unreleased* section in CHANGELOG.md has been amended to reflect the changes in this PR if needed
- [x] Build (`mvn verify`) was run locally and any changes were pushed
- [X] The pull request is against the correct branch (`master` for bug fixes, `develop` for new functionality)
- [x] [Dependencies and citation templates](https://github.com/hexatomic/hexatomic/tree/develop/releng/templates) have been updated where necessary **or** there are no new dependencies

---

# Checklist for maintainers

## Releases

- Do **NOT** push the green merge button on GitHub.  
Follow the latest version of the [developer/maintainer docs](https://hexatomic.github.io/hexatomic/dev/) for making releases.
- Check that license and citation information for dependencies are complete (each dependency has a folder in `/THIRD-PARTY/`).
