### PR TITLE
Speed up UI tests

### DIFF
--- a/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestGridEditor.java
+++ b/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestGridEditor.java
@@ -549,7 +549,7 @@ public class TestGridEditor {
     SWTBotRootMenu contextMenu = table.contextMenu(1, 1);
     // No context menu should exist 
     assertTrue(contextMenu.menuItems().isEmpty());
-    assertThrows(WidgetNotFoundException.class, () -> contextMenu.contextMenu());
+    assertThrows(WidgetNotFoundException.class, contextMenu::contextMenu);
   }
 
   @Test

--- a/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestGridEditor.java
+++ b/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestGridEditor.java
@@ -33,6 +33,7 @@ import org.eclipse.swtbot.swt.finder.keyboard.KeyboardFactory;
 import org.eclipse.swtbot.swt.finder.keyboard.Keystrokes;
 import org.eclipse.swtbot.swt.finder.waits.DefaultCondition;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotCombo;
+import org.eclipse.swtbot.swt.finder.widgets.SWTBotRootMenu;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotTreeItem;
 import org.eclipse.swtbot.swt.finder.widgets.TimeoutException;
 import org.junit.jupiter.api.AfterEach;
@@ -545,8 +546,9 @@ public class TestGridEditor {
     SWTNatTableBot tableBot = new SWTNatTableBot();
     SWTBotNatTable table = tableBot.nattable();
     table.click(1, 1);
-    assertThrows(WidgetNotFoundException.class,
-        () -> table.contextMenu(1, 1).contextMenu("Delete cell(s)"));
+    SWTBotRootMenu contextMenu = table.contextMenu(1, 1);
+    assertTrue(contextMenu.menuItems().isEmpty());
+    assertThrows(WidgetNotFoundException.class, () -> contextMenu.contextMenu());
   }
 
   @Test

--- a/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestGridEditor.java
+++ b/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestGridEditor.java
@@ -557,8 +557,9 @@ public class TestGridEditor {
 
     SWTNatTableBot tableBot = new SWTNatTableBot();
     SWTBotNatTable table = tableBot.nattable();
-    assertThrows(WidgetNotFoundException.class,
-        () -> table.contextMenu(1, 1).contextMenu("Delete cell(s)"));
+    SWTBotRootMenu contextMenu = table.contextMenu(1, 1);
+    assertTrue(contextMenu.menuItems().isEmpty());
+    assertThrows(WidgetNotFoundException.class, () -> contextMenu.contextMenu());
   }
 
 }

--- a/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestGridEditor.java
+++ b/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestGridEditor.java
@@ -561,7 +561,7 @@ public class TestGridEditor {
     SWTBotRootMenu contextMenu = table.contextMenu(1, 1);
     // No context menu should exist
     assertTrue(contextMenu.menuItems().isEmpty());
-    assertThrows(WidgetNotFoundException.class, () -> contextMenu.contextMenu());
+    assertThrows(WidgetNotFoundException.class, contextMenu::contextMenu);
   }
 
 }

--- a/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestGridEditor.java
+++ b/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestGridEditor.java
@@ -547,6 +547,7 @@ public class TestGridEditor {
     SWTBotNatTable table = tableBot.nattable();
     table.click(1, 1);
     SWTBotRootMenu contextMenu = table.contextMenu(1, 1);
+    // No context menu should exist 
     assertTrue(contextMenu.menuItems().isEmpty());
     assertThrows(WidgetNotFoundException.class, () -> contextMenu.contextMenu());
   }
@@ -558,6 +559,7 @@ public class TestGridEditor {
     SWTNatTableBot tableBot = new SWTNatTableBot();
     SWTBotNatTable table = tableBot.nattable();
     SWTBotRootMenu contextMenu = table.contextMenu(1, 1);
+    // No context menu should exist
     assertTrue(contextMenu.menuItems().isEmpty());
     assertThrows(WidgetNotFoundException.class, () -> contextMenu.contextMenu());
   }


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help. -->

## Pull request type
- Refactoring (no functional changes, no API changes)
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 
Choose one of the following types (you can copy and paste them if you like)

- Bugfix
- Feature
- Code style update (formatting, renaming)
- Refactoring (no functional changes, no API changes)
- Build related changes
- Documentation content changes
- Other (please describe it)

--> 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently, `GridEditorTest` tests the absence of a specific context menu through calling the menu directly and waiting for a `WidgetNotFOundException`, which has a timeout penalty of 5000ms for each test. This leads to long waits during the tests.


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- As in the two tests checking the above-mentioned conditions, no context menu should exist (yet) in the first place, the test is instead run to check that the parent menu is empty. This speeds up the UI tests by 10 whole seconds.

## Does this introduce a breaking change?

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

No.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->


## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added **or** the PR is neither a bug fix nor a feature
- [x] Docs have been reviewed and added / updated if needed **or** the PR is neither a bug fix nor a feature
- [x] The *Unreleased* section in CHANGELOG.md has been amended to reflect the changes in this PR if needed
- [x] Build (`mvn verify`) was run locally and any changes were pushed
- [x] The pull request is against the correct branch (`master` for bug fixes, `develop` for new functionality)
- [x] [Dependencies and citation templates](https://github.com/hexatomic/hexatomic/tree/develop/releng/templates) have been updated where necessary **or** there are no new dependencies

---

# Checklist for maintainers

## Releases

- Do **NOT** push the green merge button on GitHub.  
Follow the latest version of the [developer/maintainer docs](https://hexatomic.github.io/hexatomic/dev/) for making releases.
- Check that license and citation information for dependencies are complete (each dependency has a folder in `/THIRD-PARTY/`).
