### PR TITLE
Do not change zoom when document does have any tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed incorrect description of unreviewed hotfixes workflow in developer/maintainer documentation
+- When adding tokens in the graph editor to a previously empty document, you don't need to zoom in anymore (#224)
 
 ## [0.4.4] - 2020-09-16
 

--- a/bundles/org.corpus_tools.hexatomic.graph/src/main/java/org/corpus_tools/hexatomic/graph/GraphEditor.java
+++ b/bundles/org.corpus_tools.hexatomic.graph/src/main/java/org/corpus_tools/hexatomic/graph/GraphEditor.java
@@ -465,7 +465,7 @@ public class GraphEditor {
     }
 
     if (scrollToFirstToken) {
-      viewer.getGraphControl().getRootLayer().setScale(0);
+      viewer.getGraphControl().getRootLayer().setScale(1.0);
       // We can only scroll to the first token after the layout has been applied, which can be
       // asynchronous
       viewer.getGraphControl().getLayoutAlgorithm()
@@ -609,7 +609,6 @@ public class GraphEditor {
     ScalableFigure figure = viewer.getGraphControl().getRootLayer();
     double oldScale = figure.getScale();
     double newScale = oldScale * factor;
-
 
     double clippedScale = Math.max(0.0625, Math.min(2.0, newScale));
 

--- a/bundles/org.corpus_tools.hexatomic.graph/src/main/java/org/corpus_tools/hexatomic/graph/GraphEditor.java
+++ b/bundles/org.corpus_tools.hexatomic.graph/src/main/java/org/corpus_tools/hexatomic/graph/GraphEditor.java
@@ -255,8 +255,9 @@ public class GraphEditor {
     consoleView = new ConsoleView(consoleViewer, sync, getGraph());
     mainSash.setWeights(new int[] {200, 100});
 
-    updateView(true, true);
-
+    SDocumentGraph graph = getGraph();
+    boolean scrollToFirstToken = graph != null && !graph.getTokens().isEmpty();
+    updateView(true, scrollToFirstToken);
   }
 
   private void registerGraphControlListeners() {
@@ -465,7 +466,7 @@ public class GraphEditor {
     }
 
     if (scrollToFirstToken) {
-      viewer.getGraphControl().getRootLayer().setScale(1.0);
+      viewer.getGraphControl().getRootLayer().setScale(0.0);
       // We can only scroll to the first token after the layout has been applied, which can be
       // asynchronous
       viewer.getGraphControl().getLayoutAlgorithm()

--- a/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestGraphEditor.java
+++ b/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestGraphEditor.java
@@ -536,8 +536,10 @@ class TestGraphEditor {
   /**
    * Regression test for https://github.com/hexatomic/hexatomic/issues/224
    * 
+   * <p>
    * It checks that if you create new token in an empty document, that the zoom level is correct and
    * the tokens are actually shown.
+   * </p>
    */
   @Test
   void testShowNewlyCreatedToken() {

--- a/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestGraphEditor.java
+++ b/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestGraphEditor.java
@@ -24,6 +24,7 @@ import org.corpus_tools.salt.common.SDocumentGraph;
 import org.corpus_tools.salt.common.SPointingRelation;
 import org.corpus_tools.salt.common.STextualDS;
 import org.eclipse.core.commands.ParameterizedCommand;
+import org.eclipse.draw2d.ScalableFigure;
 import org.eclipse.draw2d.Viewport;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.e4.core.commands.ECommandService;
@@ -211,6 +212,21 @@ class TestGraphEditor {
     assertNotNull(docMenu.contextMenu("Open with Graph Editor").click());
 
     bot.waitUntil(new GraphLoadedCondition(0));
+  }
+
+  void openMinimalProjectStructure() {
+    TestCorpusStructure.createMinimalCorpusStructure(bot);
+
+    // Select the first example document
+    SWTBotTreeItem docMenu =
+        bot.partById("org.corpus_tools.hexatomic.corpusedit.part.corpusstructure").bot().tree()
+            .expandNode("corpus_graph_1").expandNode("corpus_1").expandNode("document_1");
+
+    // Select and open the editor
+    docMenu.click();
+    assertNotNull(docMenu.contextMenu("Open with Graph Editor").click());
+
+    bot.waitUntil(new GraphLoadedCondition("document_1"));
   }
 
   void enterCommand(String command) {
@@ -487,19 +503,7 @@ class TestGraphEditor {
    */
   @Test
   void testTokenizeSaveTokenizeSave() throws IOException {
-    TestCorpusStructure.createMinimalCorpusStructure(bot);
-
-    // Select the first example document
-    SWTBotTreeItem docMenu =
-        bot.partById("org.corpus_tools.hexatomic.corpusedit.part.corpusstructure").bot().tree()
-            .expandNode("corpus_graph_1").expandNode("corpus_1").expandNode("document_1");
-
-    // Select and open the editor
-    docMenu.click();
-    assertNotNull(docMenu.contextMenu("Open with Graph Editor").click());
-
-    bot.waitUntil(new GraphLoadedCondition("document_1"));
-
+    openMinimalProjectStructure();
 
     // Add the two tokens to the document graph
     enterCommand("t Oi!");
@@ -527,5 +531,28 @@ class TestGraphEditor {
 
     // The last save should not have triggered any errors
     assertFalse(errorService.getLastException().isPresent());
+  }
+
+  /**
+   * Regression test for https://github.com/hexatomic/hexatomic/issues/224
+   * 
+   * It checks that if you create new token in an empty document, that the zoom level is correct and
+   * the tokens are actually shown.
+   */
+  @Test
+  void testShowNewlyCreatedToken() {
+    openMinimalProjectStructure();
+
+    // Add some token
+    enterCommand("t This is an example.");
+
+    // Make sure the token node boxes are large enough to be visible
+    Graph g = bot.widget(widgetOfType(Graph.class));
+    assertNotNull(g);
+    bot.waitUntil(new NumberOfNodesCondition(5));
+
+    ScalableFigure figure = g.getRootLayer();
+    assertEquals(1.0, figure.getScale());
+
   }
 }


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help. -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 
Choose one of the following types (you can copy and paste them if you like)

- Bugfix
- Feature
- Code style update (formatting, renaming)
- Refactoring (no functional changes, no API changes)
- Build related changes
- Documentation content changes
- Other (please describe it)

--> 

Bugfix (but not an urgent hot fix)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Empty documents with no tokens have the scale `0.0` which makes newly added token invisible.

Issue Number: #224 


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- The constructor only zooms in onto the initial token when there are some
- Added a test case


## Does this introduce a breaking change?

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

N/A

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->


## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added **or** the PR is neither a bug fix nor a feature
- [x] Docs have been reviewed and added / updated if needed **or** the PR is neither a bug fix nor a feature
- [x] The *Unreleased* section in CHANGELOG.md has been amended to reflect the changes in this PR if needed
- [x] Build (`mvn verify`) was run locally and any changes were pushed
- [x] The pull request is against the correct branch (`master` for bug fixes, `develop` for new functionality)
- [x] [Dependencies and citation templates](https://github.com/hexatomic/hexatomic/tree/develop/releng/templates) have been updated where necessary **or** there are no new dependencies

---

# Checklist for maintainers

## Releases

- Do **NOT** push the green merge button on GitHub.  
Follow the latest version of the [developer/maintainer docs](https://hexatomic.github.io/hexatomic/dev/) for making releases.
- Check that license and citation information for dependencies are complete (each dependency has a folder in `/THIRD-PARTY/`).
