### PR TITLE
Fix target platform issue with running UI integration test from within Eclipse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed incorrect description of unreviewed hotfixes workflow in developer/maintainer documentation
 - When adding tokens in the graph editor to a previously empty document, you don't need to zoom in anymore (#224)
+- UI Integration tests can be run in Eclipse without depending on the JUnit runtime that's packaged with the IDE
 
 ## [0.4.4] - 2020-09-16
 

--- a/releng/org.corpus_tools.hexatomic.target/org.corpus_tools.hexatomic.target.target
+++ b/releng/org.corpus_tools.hexatomic.target/org.corpus_tools.hexatomic.target.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="Hexatomic Target Platform Definition" sequenceNumber="1592811653">
+<target name="Hexatomic Target Platform Definition" sequenceNumber="1603872219">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="true" type="InstallableUnit">
       <unit id="org.eclipse.platform.sdk" version="4.15.0.I20200305-0155"/>
@@ -20,6 +20,7 @@
       <unit id="org.eclipse.swtbot.go" version="2.8.0.201906121535"/>
       <unit id="org.eclipse.swtbot.swt.finder" version="2.8.0.201906121535"/>
       <unit id="org.eclipse.jface" version="3.19.0.v20200218-1607"/>
+      <unit id="org.eclipse.pde.junit.runtime" version="3.5.700.v20200116-1804"/>
       <repository location="http://download.eclipse.org/releases/2020-03/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="true" type="InstallableUnit">

--- a/releng/org.corpus_tools.hexatomic.target/org.corpus_tools.hexatomic.target.tpd
+++ b/releng/org.corpus_tools.hexatomic.target/org.corpus_tools.hexatomic.target.tpd
@@ -19,6 +19,7 @@ location 'http://download.eclipse.org/releases/2020-03/' {
 	org.eclipse.swtbot.go
 	org.eclipse.swtbot.swt.finder
 	org.eclipse.jface
+	org.eclipse.pde.junit.runtime
 }
 
 location 'https://download.eclipse.org/tools/orbit/downloads/drops/R20190602212107/repository/' {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help. -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 
Choose one of the following types (you can copy and paste them if you like)

- Bugfix
- Feature
- Code style update (formatting, renaming)
- Refactoring (no functional changes, no API changes)
- Build related changes
- Documentation content changes
- Other (please describe it)

--> 

Development setup issue

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

After updating the Eclipse IDE, the UI integration tests fail to run. According to [this Stackoverflow answer](https://stackoverflow.com/a/37160751/731040), this is because the IDE Junit runtime may fit the Eclipse runtime in one version, but not in another. The suggested solution is to add `org eclipse.pde.junit.runtime` to the target platform, which is what this pull request does. This fixes the issue.

![junit](https://user-images.githubusercontent.com/3007126/97409595-33844b80-18fe-11eb-8cb9-376bbdcf8169.gif)



## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- The UI Integration tests run independently of the JUnit Runtime packaged with the IDE, as it is packaged in the target platform.

## Does this introduce a breaking change?

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

No.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->


## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added **or** the PR is neither a bug fix nor a feature
- [x] Docs have been reviewed and added / updated if needed **or** the PR is neither a bug fix nor a feature
- [x] The *Unreleased* section in CHANGELOG.md has been amended to reflect the changes in this PR if needed
- [x] Build (`mvn verify`) was run locally and any changes were pushed
- [x] The pull request is against the correct branch (`master` for bug fixes, `develop` for new functionality)
- [x] [Dependencies and citation templates](https://github.com/hexatomic/hexatomic/tree/develop/releng/templates) have been updated where necessary **or** there are no new dependencies  
**(New dependency is not packaged with product)**

---

# Checklist for maintainers

## Releases

- Do **NOT** push the green merge button on GitHub.  
Follow the latest version of the [developer/maintainer docs](https://hexatomic.github.io/hexatomic/dev/) for making releases.
- Check that license and citation information for dependencies are complete (each dependency has a folder in `/THIRD-PARTY/`).
