### PR TITLE
Tune ratio between corpus structure editor and editor parts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Using GitHub Actions instead of Travis CI for testing the pull requests
 - Update Tycho (build-system related) to version 1.7.0
+- Ratio between corpus structure editor and editor window is now 30/70 at start
 
 ## [0.4.4] - 2020-09-16
 

--- a/bundles/org.corpus_tools.hexatomic.core/Application.e4xmi
+++ b/bundles/org.corpus_tools.hexatomic.core/Application.e4xmi
@@ -2,8 +2,8 @@
 <application:Application xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:application="http://www.eclipse.org/ui/2010/UIModel/application" xmlns:basic="http://www.eclipse.org/ui/2010/UIModel/application/ui/basic" xmlns:menu="http://www.eclipse.org/ui/2010/UIModel/application/ui/menu" xmi:id="_c3AF0MjYEeSyMNYR5xypkQ" elementId="org.eclipse.e4.application" bindingContexts="_c3AF2cjYEeSyMNYR5xypkQ">
   <children xsi:type="basic:TrimmedWindow" xmi:id="_c3AF0cjYEeSyMNYR5xypkQ" elementId="org.eclipse.e4.window.main" label="Hexatomic" iconURI="" bindingContexts="_c3AF2cjYEeSyMNYR5xypkQ" width="800" height="600">
     <children xsi:type="basic:PartSashContainer" xmi:id="_GasGEMpvEemUdItNeSusZw" elementId="org.corpus_tools.hexatomic.core.partsashcontainer.0" horizontal="true">
-      <children xsi:type="basic:PartStack" xmi:id="_Hs-NUMpvEemUdItNeSusZw" elementId="org.corpus_tools.hexatomic.core.left"/>
-      <children xsi:type="basic:PartStack" xmi:id="_UiZAkMpvEemUdItNeSusZw" elementId="org.corpus_tools.hexatomic.core.main">
+      <children xsi:type="basic:PartStack" xmi:id="_Hs-NUMpvEemUdItNeSusZw" elementId="org.corpus_tools.hexatomic.core.left" containerData="25"/>
+      <children xsi:type="basic:PartStack" xmi:id="_UiZAkMpvEemUdItNeSusZw" elementId="org.corpus_tools.hexatomic.core.main" containerData="75">
         <tags>org.corpus_tools.hexatomic.tag.editor</tags>
       </children>
     </children>

--- a/bundles/org.corpus_tools.hexatomic.core/Application.e4xmi
+++ b/bundles/org.corpus_tools.hexatomic.core/Application.e4xmi
@@ -1,10 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<application:Application xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:application="http://www.eclipse.org/ui/2010/UIModel/application" xmlns:basic="http://www.eclipse.org/ui/2010/UIModel/application/ui/basic" xmlns:menu="http://www.eclipse.org/ui/2010/UIModel/application/ui/menu" xmi:id="_c3AF0MjYEeSyMNYR5xypkQ" elementId="org.eclipse.e4.application" bindingContexts="_c3AF2cjYEeSyMNYR5xypkQ">
-  <children xsi:type="basic:TrimmedWindow" xmi:id="_c3AF0cjYEeSyMNYR5xypkQ" elementId="org.eclipse.e4.window.main" label="Hexatomic" iconURI="" bindingContexts="_c3AF2cjYEeSyMNYR5xypkQ" width="800" height="600">
-    <children xsi:type="basic:PartSashContainer" xmi:id="_GasGEMpvEemUdItNeSusZw" elementId="org.corpus_tools.hexatomic.core.partsashcontainer.0" horizontal="true">
-      <children xsi:type="basic:PartStack" xmi:id="_Hs-NUMpvEemUdItNeSusZw" elementId="org.corpus_tools.hexatomic.core.left" containerData="25"/>
-      <children xsi:type="basic:PartStack" xmi:id="_UiZAkMpvEemUdItNeSusZw" elementId="org.corpus_tools.hexatomic.core.main" containerData="75">
-        <tags>org.corpus_tools.hexatomic.tag.editor</tags>
+<application:Application xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:advanced="http://www.eclipse.org/ui/2010/UIModel/application/ui/advanced" xmlns:application="http://www.eclipse.org/ui/2010/UIModel/application" xmlns:basic="http://www.eclipse.org/ui/2010/UIModel/application/ui/basic" xmlns:menu="http://www.eclipse.org/ui/2010/UIModel/application/ui/menu" xmi:id="_c3AF0MjYEeSyMNYR5xypkQ" elementId="org.eclipse.e4.application" bindingContexts="_c3AF2cjYEeSyMNYR5xypkQ">
+  <children xsi:type="basic:TrimmedWindow" xmi:id="_c3AF0cjYEeSyMNYR5xypkQ" elementId="org.eclipse.e4.window.main" selectedElement="_470WgASgEeqYQsqyvqiQDg" label="Hexatomic" iconURI="" bindingContexts="_c3AF2cjYEeSyMNYR5xypkQ" width="800" height="600">
+    <children xsi:type="advanced:PerspectiveStack" xmi:id="_470WgASgEeqYQsqyvqiQDg" elementId="org.corpus_tools.hexatomic.core.perspectivestack.0">
+      <children xsi:type="advanced:Perspective" xmi:id="_67PQkASgEeqYQsqyvqiQDg" elementId="org.corpus_tools.hexatomic.core.perspective.0">
+        <children xsi:type="basic:PartSashContainer" xmi:id="_GasGEMpvEemUdItNeSusZw" elementId="org.corpus_tools.hexatomic.core.partsashcontainer.0" horizontal="true">
+          <children xsi:type="basic:PartStack" xmi:id="_Hs-NUMpvEemUdItNeSusZw" elementId="org.corpus_tools.hexatomic.core.left" containerData="25"/>
+          <children xsi:type="basic:PartStack" xmi:id="_UiZAkMpvEemUdItNeSusZw" elementId="org.corpus_tools.hexatomic.core.main" containerData="75">
+            <tags>org.corpus_tools.hexatomic.tag.editor</tags>
+          </children>
+        </children>
       </children>
     </children>
     <mainMenu xmi:id="_tiknoMsLEemUdItNeSusZw" elementId="org.corpus_tools.hexatomic.core.menu.0">

--- a/bundles/org.corpus_tools.hexatomic.core/Application.e4xmi
+++ b/bundles/org.corpus_tools.hexatomic.core/Application.e4xmi
@@ -1,14 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<application:Application xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:advanced="http://www.eclipse.org/ui/2010/UIModel/application/ui/advanced" xmlns:application="http://www.eclipse.org/ui/2010/UIModel/application" xmlns:basic="http://www.eclipse.org/ui/2010/UIModel/application/ui/basic" xmlns:menu="http://www.eclipse.org/ui/2010/UIModel/application/ui/menu" xmi:id="_c3AF0MjYEeSyMNYR5xypkQ" elementId="org.eclipse.e4.application" bindingContexts="_c3AF2cjYEeSyMNYR5xypkQ">
-  <children xsi:type="basic:TrimmedWindow" xmi:id="_c3AF0cjYEeSyMNYR5xypkQ" elementId="org.eclipse.e4.window.main" selectedElement="_470WgASgEeqYQsqyvqiQDg" label="Hexatomic" iconURI="" bindingContexts="_c3AF2cjYEeSyMNYR5xypkQ" width="800" height="600">
-    <children xsi:type="advanced:PerspectiveStack" xmi:id="_470WgASgEeqYQsqyvqiQDg" elementId="org.corpus_tools.hexatomic.core.perspectivestack.0">
-      <children xsi:type="advanced:Perspective" xmi:id="_67PQkASgEeqYQsqyvqiQDg" elementId="org.corpus_tools.hexatomic.core.perspective.0">
-        <children xsi:type="basic:PartSashContainer" xmi:id="_GasGEMpvEemUdItNeSusZw" elementId="org.corpus_tools.hexatomic.core.partsashcontainer.0" horizontal="true">
-          <children xsi:type="basic:PartStack" xmi:id="_Hs-NUMpvEemUdItNeSusZw" elementId="org.corpus_tools.hexatomic.core.left"/>
-          <children xsi:type="basic:PartStack" xmi:id="_UiZAkMpvEemUdItNeSusZw" elementId="org.corpus_tools.hexatomic.core.main">
-            <tags>org.corpus_tools.hexatomic.tag.editor</tags>
-          </children>
-        </children>
+<application:Application xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:application="http://www.eclipse.org/ui/2010/UIModel/application" xmlns:basic="http://www.eclipse.org/ui/2010/UIModel/application/ui/basic" xmlns:menu="http://www.eclipse.org/ui/2010/UIModel/application/ui/menu" xmi:id="_c3AF0MjYEeSyMNYR5xypkQ" elementId="org.eclipse.e4.application" bindingContexts="_c3AF2cjYEeSyMNYR5xypkQ">
+  <children xsi:type="basic:TrimmedWindow" xmi:id="_c3AF0cjYEeSyMNYR5xypkQ" elementId="org.eclipse.e4.window.main" label="Hexatomic" iconURI="" bindingContexts="_c3AF2cjYEeSyMNYR5xypkQ" width="800" height="600">
+    <children xsi:type="basic:PartSashContainer" xmi:id="_GasGEMpvEemUdItNeSusZw" elementId="org.corpus_tools.hexatomic.core.partsashcontainer.0" horizontal="true">
+      <children xsi:type="basic:PartStack" xmi:id="_Hs-NUMpvEemUdItNeSusZw" elementId="org.corpus_tools.hexatomic.core.left"/>
+      <children xsi:type="basic:PartStack" xmi:id="_UiZAkMpvEemUdItNeSusZw" elementId="org.corpus_tools.hexatomic.core.main">
+        <tags>org.corpus_tools.hexatomic.tag.editor</tags>
       </children>
     </children>
     <mainMenu xmi:id="_tiknoMsLEemUdItNeSusZw" elementId="org.corpus_tools.hexatomic.core.menu.0">

--- a/bundles/org.corpus_tools.hexatomic.core/Application.e4xmi
+++ b/bundles/org.corpus_tools.hexatomic.core/Application.e4xmi
@@ -4,8 +4,8 @@
     <children xsi:type="advanced:PerspectiveStack" xmi:id="_470WgASgEeqYQsqyvqiQDg" elementId="org.corpus_tools.hexatomic.core.perspectivestack.0">
       <children xsi:type="advanced:Perspective" xmi:id="_67PQkASgEeqYQsqyvqiQDg" elementId="org.corpus_tools.hexatomic.core.perspective.0">
         <children xsi:type="basic:PartSashContainer" xmi:id="_GasGEMpvEemUdItNeSusZw" elementId="org.corpus_tools.hexatomic.core.partsashcontainer.0" horizontal="true">
-          <children xsi:type="basic:PartStack" xmi:id="_Hs-NUMpvEemUdItNeSusZw" elementId="org.corpus_tools.hexatomic.core.left" containerData="25"/>
-          <children xsi:type="basic:PartStack" xmi:id="_UiZAkMpvEemUdItNeSusZw" elementId="org.corpus_tools.hexatomic.core.main" containerData="75">
+          <children xsi:type="basic:PartStack" xmi:id="_Hs-NUMpvEemUdItNeSusZw" elementId="org.corpus_tools.hexatomic.core.left" containerData="30"/>
+          <children xsi:type="basic:PartStack" xmi:id="_UiZAkMpvEemUdItNeSusZw" elementId="org.corpus_tools.hexatomic.core.main" containerData="70">
             <tags>org.corpus_tools.hexatomic.tag.editor</tags>
           </children>
         </children>

--- a/bundles/org.corpus_tools.hexatomic.corpusedit/src/main/java/org/corpus_tools/hexatomic/corpusedit/CorpusStructureView.java
+++ b/bundles/org.corpus_tools.hexatomic.corpusedit/src/main/java/org/corpus_tools/hexatomic/corpusedit/CorpusStructureView.java
@@ -217,10 +217,7 @@ public class CorpusStructureView {
     });
 
     Composite composite = new Composite(parent, SWT.NONE);
-    GridData gridComposite = new GridData(SWT.FILL, SWT.FILL, true, true, 1, 1);
-    gridComposite.minimumWidth = 300;
-    gridComposite.minimumHeight = 200;
-    composite.setLayoutData(gridComposite);
+    composite.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 1, 1));
     composite.setLayout(new TreeColumnLayout());
 
     treeViewer = new TreeViewer(composite, SWT.BORDER);


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help. -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 
Choose one of the following types (you can copy and paste them if you like)

- Bugfix
- Feature
- Code style update (formatting, renaming)
- Refactoring (no functional changes, no API changes)
- Build related changes
- Documentation content changes
- Other (please describe it)

--> 

Feature

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

At startup, the corpus structure editor takes 50% of the horizontal space of the whole view. Since we mostly want to edit the documents and not the structure, the lack of space for the actual editor is often very annoying.

Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Using a 30% of the horizontal space for the corpus structure editor at startup (can be changed of course)
- Fixing an issue whre the text field of the filter was not resized when the corpus structure editor was smaller.

## Does this introduce a breaking change?

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

N/A

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->


## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added **or** the PR is neither a bug fix nor a feature
- [x] Docs have been reviewed and added / updated if needed **or** the PR is neither a bug fix nor a feature
- [x] The *Unreleased* section in CHANGELOG.md has been amended to reflect the changes in this PR if needed
- [x] Build (`mvn verify`) was run locally and any changes were pushed
- [x] The pull request is against the correct branch (`master` for bug fixes, `develop` for new functionality)
- [x] [Dependencies and citation templates](https://github.com/hexatomic/hexatomic/tree/develop/releng/templates) have been updated where necessary **or** there are no new dependencies

---

# Checklist for maintainers

## Releases

- Do **NOT** push the green merge button on GitHub.  
Follow the latest version of the [developer/maintainer docs](https://hexatomic.github.io/hexatomic/dev/) for making releases.
- Check that license and citation information for dependencies are complete (each dependency has a folder in `/THIRD-PARTY/`).
