### PR TITLE
Fix deletion of selected cells

### DIFF
--- a/bundles/org.corpus_tools.hexatomic.graph/src/main/java/org/corpus_tools/hexatomic/console/internal/SyntaxListener.java
+++ b/bundles/org.corpus_tools.hexatomic.graph/src/main/java/org/corpus_tools/hexatomic/console/internal/SyntaxListener.java
@@ -21,8 +21,6 @@
 
 package org.corpus_tools.hexatomic.console.internal;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;

--- a/bundles/org.corpus_tools.hexatomic.grid/src/main/java/org/corpus_tools/hexatomic/grid/GridEditor.java
+++ b/bundles/org.corpus_tools.hexatomic.grid/src/main/java/org/corpus_tools/hexatomic/grid/GridEditor.java
@@ -91,8 +91,8 @@ import org.eclipse.swt.widgets.Label;
  */
 public class GridEditor {
 
-  /** 
-   * SWT data key used to store a reference to {@link ControlDecoration} of a component. 
+  /**
+   * SWT data key used to store a reference to {@link ControlDecoration} of a component.
    */
   public static final String CONTROL_DECORATION = "CONTROL_DECORATION";
 
@@ -196,8 +196,8 @@ public class GridEditor {
     table.addConfiguration(new StyleConfiguration());
     table.addConfiguration(new ColumnHeaderMenuConfiguration(table));
     table.addConfiguration(new FreezeGridBindings());
-    table.addConfiguration(
-        new EditConfiguration(bodyDataProvider, labelAccumulator, selectionLayer, compositeFreezeLayer));
+    table.addConfiguration(new EditConfiguration(bodyDataProvider, labelAccumulator, selectionLayer,
+        compositeFreezeLayer));
     table.addConfiguration(new BodyMenuConfiguration(table, selectionLayer));
 
     table.configure();

--- a/bundles/org.corpus_tools.hexatomic.grid/src/main/java/org/corpus_tools/hexatomic/grid/GridEditor.java
+++ b/bundles/org.corpus_tools.hexatomic.grid/src/main/java/org/corpus_tools/hexatomic/grid/GridEditor.java
@@ -197,7 +197,7 @@ public class GridEditor {
     table.addConfiguration(new ColumnHeaderMenuConfiguration(table));
     table.addConfiguration(new FreezeGridBindings());
     table.addConfiguration(
-        new EditConfiguration(bodyDataProvider, labelAccumulator, selectionLayer));
+        new EditConfiguration(bodyDataProvider, labelAccumulator, selectionLayer, compositeFreezeLayer));
     table.addConfiguration(new BodyMenuConfiguration(table, selectionLayer));
 
     table.configure();

--- a/bundles/org.corpus_tools.hexatomic.grid/src/main/java/org/corpus_tools/hexatomic/grid/internal/configuration/EditConfiguration.java
+++ b/bundles/org.corpus_tools.hexatomic.grid/src/main/java/org/corpus_tools/hexatomic/grid/internal/configuration/EditConfiguration.java
@@ -24,6 +24,8 @@ package org.corpus_tools.hexatomic.grid.internal.configuration;
 import org.corpus_tools.hexatomic.grid.internal.data.GraphDataProvider;
 import org.corpus_tools.hexatomic.grid.internal.data.GridDisplayConverter;
 import org.corpus_tools.hexatomic.grid.internal.data.LabelAccumulator;
+import org.corpus_tools.hexatomic.grid.internal.handlers.GridDeleteSelectionCommandHandler;
+import org.corpus_tools.hexatomic.grid.internal.layers.GridFreezeLayer;
 import org.eclipse.nebula.widgets.nattable.config.AbstractRegistryConfiguration;
 import org.eclipse.nebula.widgets.nattable.config.CellConfigAttributes;
 import org.eclipse.nebula.widgets.nattable.config.IConfigRegistry;
@@ -49,6 +51,7 @@ public class EditConfiguration extends AbstractRegistryConfiguration {
   private final LabelAccumulator labelAccumulator;
   private final SelectionLayer selectionLayer;
   private final GraphDataProvider bodyDataProvider;
+  private final GridFreezeLayer compositeFreezeLayer;
 
   /**
    * Constructor setting fields.
@@ -56,12 +59,14 @@ public class EditConfiguration extends AbstractRegistryConfiguration {
    * @param bodyDataProvider The current data provider for the table being configured
    * @param labelAccumulator The current label accumulator
    * @param selectionLayer The current selection layer
+   * @param compositeFreezeLayer The composite freeze layer
    */
   public EditConfiguration(GraphDataProvider bodyDataProvider, LabelAccumulator labelAccumulator,
-      SelectionLayer selectionLayer) {
+      SelectionLayer selectionLayer, GridFreezeLayer compositeFreezeLayer) {
     this.bodyDataProvider = bodyDataProvider;
     this.labelAccumulator = labelAccumulator;
     this.selectionLayer = selectionLayer;
+    this.compositeFreezeLayer = compositeFreezeLayer;
   }
 
   @Override
@@ -95,7 +100,7 @@ public class EditConfiguration extends AbstractRegistryConfiguration {
 
   @Override
   public void configureLayer(ILayer layer) {
-    layer.registerCommandHandler(new DeleteSelectionCommandHandler(this.selectionLayer));
+    layer.registerCommandHandler(new GridDeleteSelectionCommandHandler(this.selectionLayer, this.compositeFreezeLayer));
   }
 
 

--- a/bundles/org.corpus_tools.hexatomic.grid/src/main/java/org/corpus_tools/hexatomic/grid/internal/configuration/EditConfiguration.java
+++ b/bundles/org.corpus_tools.hexatomic.grid/src/main/java/org/corpus_tools/hexatomic/grid/internal/configuration/EditConfiguration.java
@@ -100,7 +100,8 @@ public class EditConfiguration extends AbstractRegistryConfiguration {
 
   @Override
   public void configureLayer(ILayer layer) {
-    layer.registerCommandHandler(new GridDeleteSelectionCommandHandler(this.selectionLayer, this.compositeFreezeLayer));
+    layer.registerCommandHandler(
+        new GridDeleteSelectionCommandHandler(this.selectionLayer, this.compositeFreezeLayer));
   }
 
 

--- a/bundles/org.corpus_tools.hexatomic.grid/src/main/java/org/corpus_tools/hexatomic/grid/internal/handlers/GridDeleteSelectionCommandHandler.java
+++ b/bundles/org.corpus_tools.hexatomic.grid/src/main/java/org/corpus_tools/hexatomic/grid/internal/handlers/GridDeleteSelectionCommandHandler.java
@@ -1,3 +1,23 @@
+/*-
+ * #%L
+ * [bundle] Hexatomic Grid Editor
+ * %%
+ * Copyright (C) 2018 - 2021 Stephan Druskat, Thomas Krause
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 package org.corpus_tools.hexatomic.grid.internal.handlers;
 
 import java.util.Arrays;

--- a/bundles/org.corpus_tools.hexatomic.grid/src/main/java/org/corpus_tools/hexatomic/grid/internal/handlers/GridDeleteSelectionCommandHandler.java
+++ b/bundles/org.corpus_tools.hexatomic.grid/src/main/java/org/corpus_tools/hexatomic/grid/internal/handlers/GridDeleteSelectionCommandHandler.java
@@ -1,0 +1,73 @@
+package org.corpus_tools.hexatomic.grid.internal.handlers;
+
+import java.util.Arrays;
+import java.util.Comparator;
+import org.eclipse.nebula.widgets.nattable.coordinate.PositionCoordinate;
+import org.eclipse.nebula.widgets.nattable.edit.command.DeleteSelectionCommand;
+import org.eclipse.nebula.widgets.nattable.edit.command.DeleteSelectionCommandHandler;
+import org.eclipse.nebula.widgets.nattable.edit.command.EditUtils;
+import org.eclipse.nebula.widgets.nattable.edit.command.UpdateDataCommand;
+import org.eclipse.nebula.widgets.nattable.layer.ILayer;
+import org.eclipse.nebula.widgets.nattable.layer.IUniqueIndexLayer;
+import org.eclipse.nebula.widgets.nattable.selection.SelectionLayer;
+
+/**
+ * Handler for deleting values in selected cells.
+ * 
+ * @see DeleteSelectionCommand
+ * 
+ * @author Stephan Druskat {@literal <mail@sdruskat.net>}
+ *
+ */
+public class GridDeleteSelectionCommandHandler extends DeleteSelectionCommandHandler {
+
+  private SelectionLayer selectionLayer;
+  private IUniqueIndexLayer upperLayer;
+
+  /**
+   * Creates a new {@link GridDeleteSelectionCommandHandler}.
+   *
+   * @param selectionLayer The {@link SelectionLayer} needed to determine the currently selected
+   *        cells.
+   */
+  public GridDeleteSelectionCommandHandler(SelectionLayer selectionLayer) {
+    super(selectionLayer, null);
+  }
+
+  /**
+   * Creates a new {@link GridDeleteSelectionCommandHandler} that performs the edit checks based on
+   * the given upper layer. Needed for example if the upper layer adds information that is needed
+   * for checks, e.g. a tree layer.
+   *
+   * @param selectionLayer The {@link SelectionLayer} needed to determine the currently selected
+   *        cells.
+   * @param upperLayer The layer on top of the given {@link SelectionLayer} to which the selection
+   *        should be converted to. Can be <code>null</code> which causes the resulting selected
+   *        cells to be related to the {@link SelectionLayer}.
+   */
+  public GridDeleteSelectionCommandHandler(SelectionLayer selectionLayer,
+      IUniqueIndexLayer upperLayer) {
+    super(selectionLayer, upperLayer);
+    this.selectionLayer = selectionLayer;
+    this.upperLayer = upperLayer;
+  }
+
+  @Override
+  public boolean doCommand(ILayer layer, DeleteSelectionCommand command) {
+    // Sort position coordinates, so that columns appear in reverse order, and are updated from the
+    // last column forwards.
+    PositionCoordinate[] coordsArray = this.selectionLayer.getSelectedCellPositions();
+    Arrays.sort(coordsArray,
+        Comparator.comparing(PositionCoordinate::getColumnPosition).reversed());
+    if (EditUtils.allCellsEditable(this.selectionLayer, this.upperLayer,
+        command.getConfigRegistry())) {
+      for (PositionCoordinate coord : coordsArray) {
+        coord.getLayer().doCommand(new UpdateDataCommand(coord.getLayer(),
+            coord.getColumnPosition(), coord.getRowPosition(), null));
+      }
+    }
+    return true;
+  }
+
+
+}

--- a/tests/.project
+++ b/tests/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.corpus_tools.hexatomic.tests</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+	<filteredResources>
+		<filter>
+			<id>1633381932051</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.core.resources.regexFilterMatcher</id>
+				<arguments>node_modules|.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
+</projectDescription>

--- a/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestGridEditor.java
+++ b/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestGridEditor.java
@@ -1530,8 +1530,7 @@ public class TestGridEditor {
     shiftClick(table, 5, 5);
     // Delete all annotations
     keyboard.pressShortcut(Keystrokes.DELETE);
-    table.click(1, 1);
-    
+    table.click(1, 1); // May be replaced by waiting for table to finish refreshing
     assertEquals(6, table.widget.getRowCount());
     assertEquals(2, table.widget.getColumnCount());
   }

--- a/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestGridEditor.java
+++ b/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestGridEditor.java
@@ -1513,6 +1513,30 @@ public class TestGridEditor {
     assertNotNull(dialog);
     assertDialogTexts(dialog, "anno9");
   }
+  
+  /**
+   * Regression test for https://github.com/hexatomic/hexatomic/issues/258:
+   * Deleting all annotations should remove all visual columns.
+   */
+  @Test
+  void testRemoveVisualColumnsOnAnnotationsDeleted() {
+    openOverlapExample();
+
+    SWTNatTableBot tableBot = new SWTNatTableBot();
+    SWTBotNatTable table = tableBot.nattable();
+
+    // Select all annotations
+    table.click(1, 2);
+    shiftClick(table, 5, 5);
+    // Delete all annotations
+    keyboard.pressShortcut(Keystrokes.DELETE);
+    table.click(1, 1);
+    
+    assertEquals(6, table.widget.getRowCount());
+    assertEquals(2, table.widget.getColumnCount());
+  }
+
+  // #################### Helper methods ####################
 
   private void assertDialogTexts(SWTBotShell dialog, String qualifiedName)
       throws InterruptedException, ExecutionException {

--- a/tests/org.corpus_tools.hexatomic.tests.report/.classpath
+++ b/tests/org.corpus_tools.hexatomic.tests.report/.classpath
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" output="target/classes" path="src/main/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.5">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" path="target/generated-sources/annotations">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="ignore_optional_problems" value="true"/>
+			<attribute name="m2e-apt" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="target/generated-test-sources/test-annotations">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="ignore_optional_problems" value="true"/>
+			<attribute name="m2e-apt" value="true"/>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/tests/org.corpus_tools.hexatomic.tests.report/.project
+++ b/tests/org.corpus_tools.hexatomic.tests.report/.project
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.corpus_tools.hexatomic.tests.report</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+	<filteredResources>
+		<filter>
+			<id>1633381932053</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.core.resources.regexFilterMatcher</id>
+				<arguments>node_modules|.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
+</projectDescription>


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help. -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 
Choose one of the following types (you can copy and paste them if you like)

- Bugfix
- Feature
- Code style update (formatting, renaming)
- Refactoring (no functional changes, no API changes)
- Build related changes
- Documentation content changes
- Other (please describe it)

--> 

- Bugfix

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #258 (https://github.com/hexatomic/hexatomic/issues/258#issuecomment-934304400)

Columns that are empty, aren't deleted right away but remain empty, which may lead to unwanted behaviour when the model columns and the visual columns diverge, as documented in #258.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Columns are removed from the visual representation as soon as they are empty, for the case where all content is deleted from the grid.
- This is achieved by reverse sorting the selected cells by column index before updating them.

## Does this introduce a breaking change?

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

No

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
The corresponding integration test may still be volatile, probably related to timing. (The table refresh may not be fast enough for the test runtime, and there is no suitable `bot.waitUntil` easily available.

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added **or** the PR is neither a bug fix nor a feature
- [ ] Docs have been reviewed and added / updated if needed **or** the PR is neither a bug fix nor a feature
- [ ] The *Unreleased* section in CHANGELOG.md has been amended to reflect the changes in this PR if needed
- [x] Build (`mvn verify`) was run locally and any changes were pushed
- [x] The pull request is against the correct branch (`master` for bug fixes, `develop` for new functionality)
- [x] [Dependencies and citation templates](https://github.com/hexatomic/hexatomic/tree/develop/releng/templates) have been updated where necessary **or** there are no new dependencies

---

# Checklist for maintainers

## Releases

- Do **NOT** push the green merge button on GitHub.  
Follow the latest version of the [developer/maintainer docs](https://hexatomic.github.io/hexatomic/dev/) for making releases.
- Check that license and citation information for dependencies are complete (each dependency has a folder in `/THIRD-PARTY/`).
