### PR TITLE
Fix #259: Show correct annotation name on rename dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Optimize column lifecycle in the Grid Editor, so that emptied columns don't disappear (#258, #346)
+- Let annotation rename dialog display the actual annotation name, not the display name of the column (#259)
 
 ## [0.8.0] - 2021-11-16
 

--- a/bundles/org.corpus_tools.hexatomic.grid/src/main/java/org/corpus_tools/hexatomic/grid/GridHelper.java
+++ b/bundles/org.corpus_tools.hexatomic.grid/src/main/java/org/corpus_tools/hexatomic/grid/GridHelper.java
@@ -20,8 +20,11 @@
 
 package org.corpus_tools.hexatomic.grid;
 
+import org.corpus_tools.hexatomic.core.errors.HexatomicRuntimeException;
+import org.corpus_tools.hexatomic.grid.internal.layers.GridColumnHeaderLayer;
 import org.corpus_tools.hexatomic.grid.internal.layers.GridFreezeLayer;
 import org.eclipse.nebula.widgets.nattable.NatTable;
+import org.eclipse.nebula.widgets.nattable.grid.layer.GridLayer;
 import org.eclipse.nebula.widgets.nattable.layer.ILayer;
 
 /**
@@ -54,6 +57,29 @@ public class GridHelper {
       layer = layer.getUnderlyingLayerByPosition(1, 1);
     }
     throw new LayerSetupException("Bottom layer of NatTable", layer, GridFreezeLayer.class);
+  }
+
+  /**
+   * Retrieves the column header layer, i.e., the {@link GridColumnHeaderLayer} for a given
+   * {@link NatTable}
+   * 
+   * @param natTable The {@link NatTable} hosting the {@link GridColumnHeaderLayer} to retrieve
+   * @return the given {@link NatTable}'s column header layer
+   */
+  public static GridColumnHeaderLayer getColumnHeaderLayer(NatTable natTable) {
+    ILayer layer = natTable.getUnderlyingLayerByPosition(0, 0);
+    if (layer instanceof GridLayer) {
+      ILayer columnHeaderLayer = ((GridLayer) layer).getColumnHeaderLayer();
+      if (columnHeaderLayer instanceof GridColumnHeaderLayer) {
+        return (GridColumnHeaderLayer) columnHeaderLayer;
+      } else {
+        throw new LayerSetupException("Column header layer of NatTable", columnHeaderLayer,
+            GridColumnHeaderLayer.class);
+      }
+    }
+    throw new HexatomicRuntimeException(
+        "Could not find a layer of type " + GridColumnHeaderLayer.class.getSimpleName()
+            + " in the NatTable. Please report this as a bug.");
   }
 
 }

--- a/bundles/org.corpus_tools.hexatomic.grid/src/main/java/org/corpus_tools/hexatomic/grid/internal/handlers/DisplayAnnotationRenameDialogOnCellsCommandHandler.java
+++ b/bundles/org.corpus_tools.hexatomic.grid/src/main/java/org/corpus_tools/hexatomic/grid/internal/handlers/DisplayAnnotationRenameDialogOnCellsCommandHandler.java
@@ -63,7 +63,7 @@ public class DisplayAnnotationRenameDialogOnCellsCommandHandler
           GridHelper.getColumnHeaderLayer(command.getNatTable());
       Integer columnIndex = command.getCellMapByColumn().keySet().iterator().next();
       int columnPosition = freezeLayer.getColumnPositionByIndex(columnIndex);
-      oldQName = (String) columnHeaderLayer.getAnnotationQName(columnPosition);
+      oldQName = columnHeaderLayer.getAnnotationQName(columnPosition);
     }
 
     AnnotationRenameDialog dialog =

--- a/bundles/org.corpus_tools.hexatomic.grid/src/main/java/org/corpus_tools/hexatomic/grid/internal/handlers/DisplayAnnotationRenameDialogOnCellsCommandHandler.java
+++ b/bundles/org.corpus_tools.hexatomic.grid/src/main/java/org/corpus_tools/hexatomic/grid/internal/handlers/DisplayAnnotationRenameDialogOnCellsCommandHandler.java
@@ -66,7 +66,9 @@ public class DisplayAnnotationRenameDialogOnCellsCommandHandler
       GridColumnHeaderLayer columnHeaderLayer = getColumnHeaderLayer(command.getNatTable());
       Integer columnIndex = command.getCellMapByColumn().keySet().iterator().next();
       int columnPosition = freezeLayer.getColumnPositionByIndex(columnIndex);
-      oldQName = (String) columnHeaderLayer.getDataValueByPosition(columnPosition, 0);
+      String displayName = (String) columnHeaderLayer.getDataValueByPosition(columnPosition, 0);
+      // Split at whitespace + '(' as this mustn't be in an annotation name
+      oldQName = displayName.split(" \\(")[0];
     }
 
     AnnotationRenameDialog dialog =

--- a/bundles/org.corpus_tools.hexatomic.grid/src/main/java/org/corpus_tools/hexatomic/grid/internal/handlers/DisplayAnnotationRenameDialogOnCellsCommandHandler.java
+++ b/bundles/org.corpus_tools.hexatomic.grid/src/main/java/org/corpus_tools/hexatomic/grid/internal/handlers/DisplayAnnotationRenameDialogOnCellsCommandHandler.java
@@ -21,18 +21,14 @@
 
 package org.corpus_tools.hexatomic.grid.internal.handlers;
 
-import org.corpus_tools.hexatomic.core.errors.HexatomicRuntimeException;
-import org.corpus_tools.hexatomic.grid.LayerSetupException;
+import org.corpus_tools.hexatomic.grid.GridHelper;
 import org.corpus_tools.hexatomic.grid.internal.commands.DisplayAnnotationRenameDialogOnCellsCommand;
 import org.corpus_tools.hexatomic.grid.internal.commands.RenameAnnotationOnCellsCommand;
 import org.corpus_tools.hexatomic.grid.internal.layers.GridColumnHeaderLayer;
 import org.corpus_tools.hexatomic.grid.internal.layers.GridFreezeLayer;
 import org.corpus_tools.hexatomic.grid.internal.ui.AnnotationRenameDialog;
-import org.eclipse.nebula.widgets.nattable.NatTable;
 import org.eclipse.nebula.widgets.nattable.columnRename.RenameColumnHeaderCommand;
 import org.eclipse.nebula.widgets.nattable.command.AbstractLayerCommandHandler;
-import org.eclipse.nebula.widgets.nattable.grid.layer.GridLayer;
-import org.eclipse.nebula.widgets.nattable.layer.ILayer;
 import org.eclipse.swt.widgets.Display;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -63,12 +59,11 @@ public class DisplayAnnotationRenameDialogOnCellsCommandHandler
     // so that it can be displayed.
     String oldQName = null;
     if (command.displayOldQName()) {
-      GridColumnHeaderLayer columnHeaderLayer = getColumnHeaderLayer(command.getNatTable());
+      GridColumnHeaderLayer columnHeaderLayer =
+          GridHelper.getColumnHeaderLayer(command.getNatTable());
       Integer columnIndex = command.getCellMapByColumn().keySet().iterator().next();
       int columnPosition = freezeLayer.getColumnPositionByIndex(columnIndex);
-      String displayName = (String) columnHeaderLayer.getDataValueByPosition(columnPosition, 0);
-      // Split at whitespace + '(' as this mustn't be in an annotation name
-      oldQName = displayName.split(" \\(")[0];
+      oldQName = (String) columnHeaderLayer.getAnnotationQName(columnPosition);
     }
 
     AnnotationRenameDialog dialog =
@@ -83,22 +78,6 @@ public class DisplayAnnotationRenameDialogOnCellsCommandHandler
     log.debug("Returning delegate command {}.", RenameColumnHeaderCommand.class.getSimpleName());
     return command.getNatTable().doCommand(new RenameAnnotationOnCellsCommand(command.getNatTable(),
         command.getCellMapByColumn(), dialog.getNewQName()));
-  }
-
-  private GridColumnHeaderLayer getColumnHeaderLayer(NatTable natTable) {
-    ILayer layer = natTable.getUnderlyingLayerByPosition(0, 0);
-    if (layer instanceof GridLayer) {
-      ILayer columnHeaderLayer = ((GridLayer) layer).getColumnHeaderLayer();
-      if (columnHeaderLayer instanceof GridColumnHeaderLayer) {
-        return (GridColumnHeaderLayer) columnHeaderLayer;
-      } else {
-        throw new LayerSetupException("Column header layer of NatTable", columnHeaderLayer,
-            GridColumnHeaderLayer.class);
-      }
-    }
-    throw new HexatomicRuntimeException(
-        "Could not find a layer of type " + GridColumnHeaderLayer.class.getSimpleName()
-            + " in the NatTable. Please report this as a bug.");
   }
 
   @Override

--- a/bundles/org.corpus_tools.hexatomic.grid/src/main/java/org/corpus_tools/hexatomic/grid/internal/handlers/DisplayAnnotationRenameDialogOnColumnCommandHandler.java
+++ b/bundles/org.corpus_tools.hexatomic.grid/src/main/java/org/corpus_tools/hexatomic/grid/internal/handlers/DisplayAnnotationRenameDialogOnColumnCommandHandler.java
@@ -21,6 +21,8 @@
 
 package org.corpus_tools.hexatomic.grid.internal.handlers;
 
+import org.corpus_tools.hexatomic.grid.LayerSetupException;
+import org.corpus_tools.hexatomic.grid.internal.layers.GridColumnHeaderLayer;
 import org.corpus_tools.hexatomic.grid.internal.ui.AnnotationRenameDialog;
 import org.eclipse.nebula.widgets.nattable.columnRename.DisplayColumnRenameDialogCommand;
 import org.eclipse.nebula.widgets.nattable.columnRename.RenameColumnHeaderCommand;
@@ -52,8 +54,15 @@ public class DisplayAnnotationRenameDialogOnColumnCommandHandler
   protected boolean doCommand(DisplayColumnRenameDialogCommand command) {
     log.debug("Executing command {}.", getCommandClass().getSimpleName());
     int columnPosition = command.getColumnPosition();
-    String displayName = this.columnHeaderLayer.getOriginalColumnLabel(columnPosition);
-    String originalQName = displayName.split(" \\(")[0];
+    String originalQName = null;
+    if (!(columnHeaderLayer instanceof GridColumnHeaderLayer)) {
+      throw new LayerSetupException("ColumnHeaderLayer", this.columnHeaderLayer,
+          GridColumnHeaderLayer.class);
+    }
+    else {
+      GridColumnHeaderLayer gridColumnHeaderLayer = (GridColumnHeaderLayer) this.columnHeaderLayer;
+      originalQName = (String) gridColumnHeaderLayer.getAnnotationQName(columnPosition);
+    }
 
     AnnotationRenameDialog dialog =
         new AnnotationRenameDialog(Display.getDefault().getActiveShell(), originalQName);

--- a/bundles/org.corpus_tools.hexatomic.grid/src/main/java/org/corpus_tools/hexatomic/grid/internal/handlers/DisplayAnnotationRenameDialogOnColumnCommandHandler.java
+++ b/bundles/org.corpus_tools.hexatomic.grid/src/main/java/org/corpus_tools/hexatomic/grid/internal/handlers/DisplayAnnotationRenameDialogOnColumnCommandHandler.java
@@ -58,8 +58,7 @@ public class DisplayAnnotationRenameDialogOnColumnCommandHandler
     if (!(columnHeaderLayer instanceof GridColumnHeaderLayer)) {
       throw new LayerSetupException("ColumnHeaderLayer", this.columnHeaderLayer,
           GridColumnHeaderLayer.class);
-    }
-    else {
+    } else {
       GridColumnHeaderLayer gridColumnHeaderLayer = (GridColumnHeaderLayer) this.columnHeaderLayer;
       originalQName = (String) gridColumnHeaderLayer.getAnnotationQName(columnPosition);
     }

--- a/bundles/org.corpus_tools.hexatomic.grid/src/main/java/org/corpus_tools/hexatomic/grid/internal/handlers/DisplayAnnotationRenameDialogOnColumnCommandHandler.java
+++ b/bundles/org.corpus_tools.hexatomic.grid/src/main/java/org/corpus_tools/hexatomic/grid/internal/handlers/DisplayAnnotationRenameDialogOnColumnCommandHandler.java
@@ -60,7 +60,7 @@ public class DisplayAnnotationRenameDialogOnColumnCommandHandler
           GridColumnHeaderLayer.class);
     } else {
       GridColumnHeaderLayer gridColumnHeaderLayer = (GridColumnHeaderLayer) this.columnHeaderLayer;
-      originalQName = (String) gridColumnHeaderLayer.getAnnotationQName(columnPosition);
+      originalQName = gridColumnHeaderLayer.getAnnotationQName(columnPosition);
     }
 
     AnnotationRenameDialog dialog =

--- a/bundles/org.corpus_tools.hexatomic.grid/src/main/java/org/corpus_tools/hexatomic/grid/internal/handlers/DisplayAnnotationRenameDialogOnColumnCommandHandler.java
+++ b/bundles/org.corpus_tools.hexatomic.grid/src/main/java/org/corpus_tools/hexatomic/grid/internal/handlers/DisplayAnnotationRenameDialogOnColumnCommandHandler.java
@@ -52,7 +52,8 @@ public class DisplayAnnotationRenameDialogOnColumnCommandHandler
   protected boolean doCommand(DisplayColumnRenameDialogCommand command) {
     log.debug("Executing command {}.", getCommandClass().getSimpleName());
     int columnPosition = command.getColumnPosition();
-    String originalQName = this.columnHeaderLayer.getOriginalColumnLabel(columnPosition);
+    String displayName = this.columnHeaderLayer.getOriginalColumnLabel(columnPosition);
+    String originalQName = displayName.split(" \\(")[0];
 
     AnnotationRenameDialog dialog =
         new AnnotationRenameDialog(Display.getDefault().getActiveShell(), originalQName);

--- a/bundles/org.corpus_tools.hexatomic.grid/src/main/java/org/corpus_tools/hexatomic/grid/internal/layers/GridColumnHeaderLayer.java
+++ b/bundles/org.corpus_tools.hexatomic.grid/src/main/java/org/corpus_tools/hexatomic/grid/internal/layers/GridColumnHeaderLayer.java
@@ -74,4 +74,25 @@ public class GridColumnHeaderLayer extends ColumnHeaderLayer {
     registerCommandHandler(new DisplayAnnotationRenameDialogOnColumnCommandHandler(this));
   }
 
+  /**
+   * Returns the first part of the column's display name as split on whitespace + '('. Using
+   * whitespaces and brackets in annotation names are discouraged, but the display name may contain
+   * them if there are more than one columns for the same qualified annotation name.
+   * 
+   * @param columnPosition The position of the column for which to retrieve the annotation name
+   * @return The qualified annotation name as determined by splitting on ' ('.
+   */
+  public String getAnnotationQName(int columnPosition) {
+    Object dataValue = super.getDataValueByPosition(columnPosition, 0);
+    if (!(dataValue instanceof String)) {
+      throw new IllegalArgumentException(
+          "Column header data values should always be strings, but got "
+              + dataValue.getClass().getCanonicalName());
+    }
+    else {
+      String dataString = (String) dataValue;
+      return dataString.split(" \\(")[0];
+    }
+  }
+
 }

--- a/bundles/org.corpus_tools.hexatomic.grid/src/main/java/org/corpus_tools/hexatomic/grid/internal/layers/GridColumnHeaderLayer.java
+++ b/bundles/org.corpus_tools.hexatomic.grid/src/main/java/org/corpus_tools/hexatomic/grid/internal/layers/GridColumnHeaderLayer.java
@@ -88,8 +88,7 @@ public class GridColumnHeaderLayer extends ColumnHeaderLayer {
       throw new IllegalArgumentException(
           "Column header data values should always be strings, but got "
               + dataValue.getClass().getCanonicalName());
-    }
-    else {
+    } else {
       String dataString = (String) dataValue;
       return dataString.split(" \\(")[0];
     }

--- a/bundles/org.corpus_tools.hexatomic.grid/src/main/java/org/corpus_tools/hexatomic/grid/internal/layers/GridColumnHeaderLayer.java
+++ b/bundles/org.corpus_tools.hexatomic.grid/src/main/java/org/corpus_tools/hexatomic/grid/internal/layers/GridColumnHeaderLayer.java
@@ -21,6 +21,8 @@
 
 package org.corpus_tools.hexatomic.grid.internal.layers;
 
+import javax.inject.Inject;
+import org.corpus_tools.hexatomic.core.errors.ErrorService;
 import org.corpus_tools.hexatomic.grid.internal.data.ColumnHeaderDataProvider;
 import org.corpus_tools.hexatomic.grid.internal.handlers.DisplayAnnotationRenameDialogOnColumnCommandHandler;
 import org.corpus_tools.hexatomic.grid.internal.handlers.RenameAnnotationOnColumnCommandHandler;
@@ -38,6 +40,9 @@ import org.eclipse.nebula.widgets.nattable.selection.SelectionLayer;
  * @author Stephan Druskat (mail@sdruskat.net)
  */
 public class GridColumnHeaderLayer extends ColumnHeaderLayer {
+
+  @Inject
+  ErrorService errors;
 
   /**
    * Constructor delegating to a ColumnHeaderLayer constructor.
@@ -83,15 +88,13 @@ public class GridColumnHeaderLayer extends ColumnHeaderLayer {
    * @return The qualified annotation name as determined by splitting on ' ('.
    */
   public String getAnnotationQName(int columnPosition) {
-    Object dataValue = super.getDataValueByPosition(columnPosition, 0);
-    if (!(dataValue instanceof String)) {
-      throw new IllegalArgumentException(
-          "Column header data values should always be strings, but got "
-              + dataValue.getClass().getCanonicalName());
-    } else {
-      String dataString = (String) dataValue;
-      return dataString.split(" \\(")[0];
+    Object dataValue = getDataValueByPosition(columnPosition, 0);
+    if (dataValue instanceof String) {
+      return ((String) dataValue).split(" \\(")[0];
     }
+    else
+      throw new IllegalArgumentException("Expected column header data value at column position "
+          + columnPosition + " to be a string, but got " + dataValue.getClass().getSimpleName());
   }
 
 }

--- a/bundles/org.corpus_tools.hexatomic.grid/src/main/java/org/corpus_tools/hexatomic/grid/internal/layers/GridColumnHeaderLayer.java
+++ b/bundles/org.corpus_tools.hexatomic.grid/src/main/java/org/corpus_tools/hexatomic/grid/internal/layers/GridColumnHeaderLayer.java
@@ -91,10 +91,10 @@ public class GridColumnHeaderLayer extends ColumnHeaderLayer {
     Object dataValue = getDataValueByPosition(columnPosition, 0);
     if (dataValue instanceof String) {
       return ((String) dataValue).split(" \\(")[0];
-    }
-    else
+    } else {
       throw new IllegalArgumentException("Expected column header data value at column position "
           + columnPosition + " to be a string, but got " + dataValue.getClass().getSimpleName());
+    }
   }
 
 }

--- a/tests/org.corpus_tools.hexatomic.grid.tests/src/main/java/org/corpus_tools/hexatomic/grid/TestGridHelper.java
+++ b/tests/org.corpus_tools.hexatomic.grid.tests/src/main/java/org/corpus_tools/hexatomic/grid/TestGridHelper.java
@@ -1,0 +1,60 @@
+package org.corpus_tools.hexatomic.grid;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.corpus_tools.hexatomic.core.errors.HexatomicRuntimeException;
+import org.corpus_tools.hexatomic.grid.internal.layers.GridColumnHeaderLayer;
+import org.eclipse.nebula.widgets.nattable.NatTable;
+import org.eclipse.nebula.widgets.nattable.grid.layer.ColumnHeaderLayer;
+import org.eclipse.nebula.widgets.nattable.grid.layer.GridLayer;
+import org.eclipse.nebula.widgets.nattable.selection.SelectionLayer;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link GridHelper}.
+ * 
+ * @author Stephan Druskat {@literal <mail@sdruskat.net>}
+ */
+class TestGridHelper {
+
+  /**
+   * Tests that the expected exceptions are thrown when the {@link NatTable} is set up wrongly.
+   */
+  @Test
+  void testGetColumnHeaderLayerThrowsHexatomicRuntimeException() {
+    NatTable table = mock(NatTable.class);
+    SelectionLayer pseudoGridLayer = mock(SelectionLayer.class);
+    when(table.getUnderlyingLayerByPosition(0, 0)).thenReturn(pseudoGridLayer);
+    assertThrows(HexatomicRuntimeException.class, () -> GridHelper.getColumnHeaderLayer(table));
+  }
+
+  /**
+   * Tests that the expected exceptions are thrown when the {@link NatTable} is set up wrongly.
+   */
+  @Test
+  void testGetColumnHeaderLayerThrowsLayerSetupException() {
+    NatTable table = mock(NatTable.class);
+    GridLayer pseudoGridLayer = mock(GridLayer.class);
+    ColumnHeaderLayer pseudoColumnHeaderLayer = mock(ColumnHeaderLayer.class);
+    when(pseudoGridLayer.getColumnHeaderLayer()).thenReturn(pseudoColumnHeaderLayer);
+    when(table.getUnderlyingLayerByPosition(0, 0)).thenReturn(pseudoGridLayer);
+    assertThrows(HexatomicRuntimeException.class, () -> GridHelper.getColumnHeaderLayer(table));
+  }
+
+  /**
+   * Tests that the {@link GridHelper#getColumnHeaderLayer(NatTable)} returns the correct value.
+   */
+  @Test
+  void testGetColumnHeaderLayer() {
+    NatTable table = mock(NatTable.class);
+    GridLayer pseudoGridLayer = mock(GridLayer.class);
+    GridColumnHeaderLayer pseudoColumnHeaderLayer = mock(GridColumnHeaderLayer.class);
+    when(pseudoGridLayer.getColumnHeaderLayer()).thenReturn(pseudoColumnHeaderLayer);
+    when(table.getUnderlyingLayerByPosition(0, 0)).thenReturn(pseudoGridLayer);
+    assertEquals(pseudoColumnHeaderLayer, GridHelper.getColumnHeaderLayer(table));
+  }
+
+}

--- a/tests/org.corpus_tools.hexatomic.grid.tests/src/main/java/org/corpus_tools/hexatomic/grid/internal/handlers/TestDisplayAnnotationRenameDialogOnColumnCommandHandler.java
+++ b/tests/org.corpus_tools.hexatomic.grid.tests/src/main/java/org/corpus_tools/hexatomic/grid/internal/handlers/TestDisplayAnnotationRenameDialogOnColumnCommandHandler.java
@@ -1,0 +1,36 @@
+package org.corpus_tools.hexatomic.grid.internal.handlers;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.corpus_tools.hexatomic.grid.LayerSetupException;
+import org.eclipse.nebula.widgets.nattable.columnRename.DisplayColumnRenameDialogCommand;
+import org.eclipse.nebula.widgets.nattable.grid.layer.ColumnHeaderLayer;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link DisplayAnnotationRenameDialogOnColumnCommandHandler}.
+ * 
+ * @author Stephan Druskat {@literal <mail@sdruskat.net>}
+ */
+class TestDisplayAnnotationRenameDialogOnColumnCommandHandler {
+
+  private static DisplayAnnotationRenameDialogOnColumnCommandHandler fixture = null;
+
+  /**
+   * <p>
+   * Tests that a {@link LayerSetupException} is thrown when the column header layer is not of the
+   * expected type.
+   * </p>
+   */
+  @Test
+  void testDoCommandDisplayColumnRenameDialogCommand() {
+    ColumnHeaderLayer layer = mock(ColumnHeaderLayer.class);
+    DisplayColumnRenameDialogCommand command = mock(DisplayColumnRenameDialogCommand.class);
+    when(command.getColumnPosition()).thenReturn(1);
+    fixture = new DisplayAnnotationRenameDialogOnColumnCommandHandler(layer);
+    assertThrows(LayerSetupException.class, () -> fixture.doCommand(command));
+  }
+
+}

--- a/tests/org.corpus_tools.hexatomic.grid.tests/src/main/java/org/corpus_tools/hexatomic/grid/internal/handlers/TestDisplayAnnotationRenameDialogOnColumnCommandHandler.java
+++ b/tests/org.corpus_tools.hexatomic.grid.tests/src/main/java/org/corpus_tools/hexatomic/grid/internal/handlers/TestDisplayAnnotationRenameDialogOnColumnCommandHandler.java
@@ -16,8 +16,6 @@ import org.junit.jupiter.api.Test;
  */
 class TestDisplayAnnotationRenameDialogOnColumnCommandHandler {
 
-  private static DisplayAnnotationRenameDialogOnColumnCommandHandler fixture = null;
-
   /**
    * <p>
    * Tests that a {@link LayerSetupException} is thrown when the column header layer is not of the
@@ -29,7 +27,8 @@ class TestDisplayAnnotationRenameDialogOnColumnCommandHandler {
     ColumnHeaderLayer layer = mock(ColumnHeaderLayer.class);
     DisplayColumnRenameDialogCommand command = mock(DisplayColumnRenameDialogCommand.class);
     when(command.getColumnPosition()).thenReturn(1);
-    fixture = new DisplayAnnotationRenameDialogOnColumnCommandHandler(layer);
+    DisplayAnnotationRenameDialogOnColumnCommandHandler fixture =
+        new DisplayAnnotationRenameDialogOnColumnCommandHandler(layer);
     assertThrows(LayerSetupException.class, () -> fixture.doCommand(command));
   }
 

--- a/tests/org.corpus_tools.hexatomic.grid.tests/src/main/java/org/corpus_tools/hexatomic/grid/internal/layers/TestGridColumnHeaderLayer.java
+++ b/tests/org.corpus_tools.hexatomic.grid.tests/src/main/java/org/corpus_tools/hexatomic/grid/internal/layers/TestGridColumnHeaderLayer.java
@@ -25,7 +25,7 @@ class TestGridColumnHeaderLayer {
   /**
    * Sets up the fixture.
    *
-   * @throws java.lang.Exception
+   * @throws java.lang.Exception Any exception that occurs
    */
   @BeforeEach
   void setUp() throws Exception {
@@ -34,19 +34,22 @@ class TestGridColumnHeaderLayer {
   }
 
   /**
-   * Test method for {@link org.eclipse.nebula.widgets.nattable.grid.layer.ColumnHeaderLayer#getDataValueByPosition(int, int)}.
+   * Test method for
+   * {@link org.eclipse.nebula.widgets.nattable.grid.layer.ColumnHeaderLayer#getDataValueByPosition(int, int)}.
    */
   @Test
   void testThrowsOnGetDataValueByPosition() {
     when(fixture.getDataValueByPosition(1, 0)).thenReturn(1L);
-    IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> fixture.getAnnotationQName(1));
+    IllegalArgumentException e =
+        assertThrows(IllegalArgumentException.class, () -> fixture.getAnnotationQName(1));
     assertEquals(
         "Expected column header data value at column position 1 to be a string, but got Long",
         e.getMessage());
   }
 
   /**
-   * Test method for {@link org.eclipse.nebula.widgets.nattable.grid.layer.ColumnHeaderLayer#getDataValueByPosition(int, int)}.
+   * Test method for
+   * {@link org.eclipse.nebula.widgets.nattable.grid.layer.ColumnHeaderLayer#getDataValueByPosition(int, int)}.
    */
   @Test
   void testGetAnnotationQNameWithNumber() {

--- a/tests/org.corpus_tools.hexatomic.grid.tests/src/main/java/org/corpus_tools/hexatomic/grid/internal/layers/TestGridColumnHeaderLayer.java
+++ b/tests/org.corpus_tools.hexatomic.grid.tests/src/main/java/org/corpus_tools/hexatomic/grid/internal/layers/TestGridColumnHeaderLayer.java
@@ -1,0 +1,67 @@
+package org.corpus_tools.hexatomic.grid.internal.layers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.eclipse.nebula.widgets.nattable.layer.ILayer;
+import org.eclipse.nebula.widgets.nattable.layer.IUniqueIndexLayer;
+import org.eclipse.nebula.widgets.nattable.selection.SelectionLayer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link GridColumnHeaderLayer}.
+ * 
+ * @author Stephan Druskat {@literal <mail@sdruskat.net>}
+ */
+class TestGridColumnHeaderLayer {
+
+  private GridColumnHeaderLayer fixture = null;
+  // Mockito.spy(new GridColumnHeaderLayer(mock(IUniqueIndexLayer.class), mock(ILayer.class),
+  // mock(SelectionLayer.class)));
+
+  /**
+   * Sets up the fixture.
+   *
+   * @throws java.lang.Exception
+   */
+  @BeforeEach
+  void setUp() throws Exception {
+    fixture = new GridColumnHeaderLayer(mock(IUniqueIndexLayer.class), mock(ILayer.class),
+        mock(SelectionLayer.class));
+  }
+
+  /**
+   * Test method for {@link org.eclipse.nebula.widgets.nattable.grid.layer.ColumnHeaderLayer#getDataValueByPosition(int, int)}.
+   */
+  @Test
+  void testThrowsOnGetDataValueByPosition() {
+    when(fixture.getDataValueByPosition(1, 0)).thenReturn(1L);
+    IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> fixture.getAnnotationQName(1));
+    assertEquals(
+        "Expected column header data value at column position 1 to be a string, but got Long",
+        e.getMessage());
+  }
+
+  /**
+   * Test method for {@link org.eclipse.nebula.widgets.nattable.grid.layer.ColumnHeaderLayer#getDataValueByPosition(int, int)}.
+   */
+  @Test
+  void testGetAnnotationQNameWithNumber() {
+    when(fixture.getDataValueByPosition(1, 0)).thenReturn("TEST (2)");
+    assertEquals("TEST", fixture.getAnnotationQName(1));
+  }
+
+  /**
+   * Test method for
+   * {@link org.eclipse.nebula.widgets.nattable.grid.layer.ColumnHeaderLayer#getDataValueByPosition(int, int)}.
+   */
+  @Test
+  void testGetAnnotationQName() {
+    when(fixture.getDataValueByPosition(1, 0)).thenReturn("TEST");
+    assertEquals("TEST", fixture.getAnnotationQName(1));
+  }
+
+}

--- a/tests/org.corpus_tools.hexatomic.grid.tests/src/main/java/org/corpus_tools/hexatomic/grid/internal/layers/TestGridColumnHeaderLayer.java
+++ b/tests/org.corpus_tools.hexatomic.grid.tests/src/main/java/org/corpus_tools/hexatomic/grid/internal/layers/TestGridColumnHeaderLayer.java
@@ -19,16 +19,12 @@ import org.junit.jupiter.api.Test;
 class TestGridColumnHeaderLayer {
 
   private GridColumnHeaderLayer fixture = null;
-  // Mockito.spy(new GridColumnHeaderLayer(mock(IUniqueIndexLayer.class), mock(ILayer.class),
-  // mock(SelectionLayer.class)));
 
   /**
    * Sets up the fixture.
-   *
-   * @throws java.lang.Exception Any exception that occurs
    */
   @BeforeEach
-  void setUp() throws Exception {
+  void setUp() {
     fixture = new GridColumnHeaderLayer(mock(IUniqueIndexLayer.class), mock(ILayer.class),
         mock(SelectionLayer.class));
   }

--- a/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestGridEditor.java
+++ b/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestGridEditor.java
@@ -1749,11 +1749,22 @@ public class TestGridEditor {
 
     assertEquals("five::span_1 (2)", table.getCellDataValueByPosition(0, 4));
 
+    // Test cell menu behaviour
     table.click(1, 4);
     table.contextMenu(1, 4).contextMenu(GridEditor.CHANGE_ANNOTATION_NAME_POPUP_MENU_LABEL).click();
 
     bot.waitUntil(Conditions.shellIsActive(RENAME_DIALOG_TITLE));
     SWTBotShell dialog = tableBot.shell(RENAME_DIALOG_TITLE);
+    assertNotNull(dialog);
+    assertDialogTexts(dialog, "five::span_1");
+    dialog.close();
+
+    // Test column menu
+    table.click(0, 4);
+    table.contextMenu(0, 4).contextMenu(GridEditor.CHANGE_ANNOTATION_NAME_POPUP_MENU_LABEL).click();
+
+    bot.waitUntil(Conditions.shellIsActive(RENAME_DIALOG_TITLE));
+    dialog = tableBot.shell(RENAME_DIALOG_TITLE);
     assertNotNull(dialog);
     assertDialogTexts(dialog, "five::span_1");
     dialog.close();

--- a/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestGridEditor.java
+++ b/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestGridEditor.java
@@ -1731,6 +1731,34 @@ public class TestGridEditor {
     dialog.close();
   }
 
+  /**
+   * Regression test for https://github.com/hexatomic/hexatomic/issues/259.
+   * 
+   * Tests that the annotation name, not the display name, is shown on columns that are secondary
+   * columns (e.g., "namespace::name (2)").
+   * 
+   * @throws ExecutionException
+   * @throws InterruptedException
+   */
+  @Test
+  void testShowCorrectAnnotationNameInDialog() throws InterruptedException, ExecutionException {
+    openOverlapExample();
+
+    SWTNatTableBot tableBot = new SWTNatTableBot();
+    SWTBotNatTable table = tableBot.nattable();
+
+    assertEquals("five::span_1 (2)", table.getCellDataValueByPosition(0, 4));
+
+    table.click(1, 4);
+    table.contextMenu(1, 4).contextMenu(GridEditor.CHANGE_ANNOTATION_NAME_POPUP_MENU_LABEL).click();
+
+    bot.waitUntil(Conditions.shellIsActive(RENAME_DIALOG_TITLE));
+    SWTBotShell dialog = tableBot.shell(RENAME_DIALOG_TITLE);
+    assertNotNull(dialog);
+    assertDialogTexts(dialog, "five::span_1");
+    dialog.close();
+  }
+
   private void assertDialogTexts(SWTBotShell dialog, String qualifiedName)
       throws InterruptedException, ExecutionException {
     String namespace = null;

--- a/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestGridEditor.java
+++ b/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestGridEditor.java
@@ -1734,11 +1734,14 @@ public class TestGridEditor {
   /**
    * Regression test for https://github.com/hexatomic/hexatomic/issues/259.
    * 
+   * <p>
    * Tests that the annotation name, not the display name, is shown on columns that are secondary
    * columns (e.g., "namespace::name (2)").
+   * </p>
    * 
-   * @throws ExecutionException
-   * @throws InterruptedException
+   * @throws InterruptedException If the thread extracting the label text in the given dialog is
+   *         interrupted, or if there is an error during execution.
+   * @throws ExecutionException See InterruptedException
    */
   @Test
   void testShowCorrectAnnotationNameInDialog() throws InterruptedException, ExecutionException {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help. -->
## :warning: Builds on #352, only merge this after merging #352 :warning: 

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 
Choose one of the following types (you can copy and paste them if you like)

- Bugfix
- Feature
- Code style update (formatting, renaming)
- Refactoring (no functional changes, no API changes)
- Build related changes
- Documentation content changes
- Other (please describe it)

--> 

- Bugfix

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #259

The annotation rename dialog shows the *display* name of the column rather than the actual annotation name (e.g., for the second column for a span annotation of `five::span_1` it shows `five::span_1 (2)`).


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Fix #259
- Rename dialog shows correct name

## Does this introduce a breaking change?

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

No

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->


## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added **or** the PR is neither a bug fix nor a feature
- [x] Docs have been reviewed and added / updated if needed **or** the PR is neither a bug fix nor a feature
- [x] The *Unreleased* section in CHANGELOG.md has been amended to reflect the changes in this PR if needed
- [x] Build (`mvn verify`) was run locally and any changes were pushed
- [x] The pull request is against the correct branch (`master` for bug fixes, `develop` for new functionality)
- [x] [Dependencies and citation templates](https://github.com/hexatomic/hexatomic/tree/develop/releng/templates) have been updated where necessary **or** there are no new dependencies

---

# Checklist for maintainers

## Releases

- Do **NOT** push the green merge button on GitHub.  
Follow the latest version of the [developer/maintainer docs](https://hexatomic.github.io/hexatomic/dev/) for making releases.
- Check that license and citation information for dependencies are complete (each dependency has a folder in `/THIRD-PARTY/`).
