### PR TITLE
Set up auto archival trigger on tags push

### DIFF
--- a/.github/workflows/archive.yml
+++ b/.github/workflows/archive.yml
@@ -1,0 +1,13 @@
+name: Auto-archive repository to Software Heritage when tags are pushed
+on: 
+  push:
+    tags:
+      - '*'
+
+jobs:
+  trigger_archival:
+    name: Trigger archival on Software Heritage
+    runs-on: ubuntu-20.04
+    steps:
+        - name: Run Software Heritage Save action
+          uses: sdruskat/swh-save-action@v1.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add auto-archival on Software Heritage whenever git tags are pushed to the repository (#21)
+
 ## [0.9.0] - 2022-05-24
 
 ### Added

--- a/docs/dev/src/maintenance/continuous-integration/README.md
+++ b/docs/dev/src/maintenance/continuous-integration/README.md
@@ -50,6 +50,17 @@ The release workflow consists of two separate jobs:
 2. A job that builds the documentation and deploys the built website to the
    `github-pages` branch of the repository, from where GitHub Pages renders it
 
+### Archive workflow
+
+The archive
+workflow (`.github/workflows/archive.yml`)
+is run whenever Git tags are pushed to the repository.
+The release workflow consists of only one job:
+
+1. A job that runs the [Software Heritage Save action](https://github.com/marketplace/actions/save-to-software-heritage)
+that triggers the Software Heritage API to save the repository to the archive.
+
+
 ## Static code analysis
 
 We use the static code analysis service SonarCloud to 


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 
Choose one of the following types (you can copy and paste them if you like)



--> 
- Build related changes

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #21

- Repository is never archived automatically on Software Heritage, unless it is crawled by them.


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Whenever a tag is pushed, the [SWH Save Action](https://github.com/marketplace/actions/save-to-software-heritage) is run, which triggers a call to the SWH API to save this repository.
- Fixes #21

## Does this introduce a breaking change?

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

No

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added **or** the PR is neither a bug fix nor a feature
- [x] Docs have been reviewed and added / updated if needed **or** the PR is neither a bug fix nor a feature
- [x] The *Unreleased* section in CHANGELOG.md has been amended to reflect the changes in this PR if needed
- [x] Build (`mvn verify`) was run locally and any changes were pushed
- [x] The pull request is against the correct branch (`master` for bug fixes, `develop` for new functionality)
- [x] [Dependencies and citation templates](https://github.com/hexatomic/hexatomic/tree/develop/releng/templates) have been updated where necessary **or** there are no new dependencies

---

# Checklist for maintainers

## Releases

- Do **NOT** push the green merge button on GitHub.  
Follow the latest version of the [developer/maintainer docs](https://hexatomic.github.io/hexatomic/dev/) for making releases.
- Check that license and citation information for dependencies are complete (each dependency has a folder in `/THIRD-PARTY/`).
