### PR TITLE
Wait until background job finishes in graph editor test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Stabilize graph editor test to wait until background jobs are finished before
+  selecting the text fragment.
+
 ## [1.0.0] - 2022-08-23
 
 ### Changed

--- a/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/NoBackgroundJobsCondition.java
+++ b/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/NoBackgroundJobsCondition.java
@@ -1,0 +1,30 @@
+package org.corpus_tools.hexatomic.it.tests;
+
+import org.corpus_tools.hexatomic.core.UiStatusReport;
+import org.eclipse.swtbot.swt.finder.waits.DefaultCondition;
+
+/**
+ * A condition that wait until there are no active background jobs.
+ * 
+ * @author Thomas Krause
+ *
+ */
+class NoBackgroundJobsCondition extends DefaultCondition {
+
+  private final UiStatusReport status;
+
+  public NoBackgroundJobsCondition(UiStatusReport status) {
+    super();
+    this.status = status;
+  }
+
+  @Override
+  public boolean test() throws Exception {
+    return status.getNumberOfExecutedJobs() == 0;
+  }
+
+  @Override
+  public String getFailureMessage() {
+    return "Background jobs did not finish";
+  }
+}

--- a/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestGraphEditor.java
+++ b/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/it/tests/TestGraphEditor.java
@@ -21,6 +21,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.corpus_tools.hexatomic.core.CommandParams;
 import org.corpus_tools.hexatomic.core.ProjectManager;
+import org.corpus_tools.hexatomic.core.UiStatusReport;
 import org.corpus_tools.hexatomic.core.errors.ErrorService;
 import org.corpus_tools.hexatomic.graph.GraphEditor;
 import org.corpus_tools.hexatomic.it.tests.utils.SwtBotChips;
@@ -93,6 +94,7 @@ class TestGraphEditor {
 
   private ErrorService errorService;
   private ProjectManager projectManager;
+  private UiStatusReport uiStatus;
 
   private final Keyboard keyboard = KeyboardFactory.getAWTKeyboard();
 
@@ -278,6 +280,7 @@ class TestGraphEditor {
 
     errorService = ContextInjectionFactory.make(ErrorService.class, ctx);
     projectManager = ContextInjectionFactory.make(ProjectManager.class, ctx);
+    uiStatus = ContextInjectionFactory.make(UiStatusReport.class, ctx);
 
     commandService = ctx.get(ECommandService.class);
     assertNotNull(commandService);
@@ -513,7 +516,6 @@ class TestGraphEditor {
 
     openDefaultExample();
 
-
     // Get a reference to the opened document graph
     Optional<SDocument> optionalDoc =
         projectManager.getDocument("salt:/rootCorpus/subCorpus1/doc1");
@@ -532,6 +534,8 @@ class TestGraphEditor {
 
       // Add a checkpoint so the changes are propagated to the view
       projectManager.addCheckpoint();
+
+      bot.waitUntil(new NoBackgroundJobsCondition(uiStatus));
 
       // Select the new text
       SWTBotTable textRangeTable = bot.tableWithId(GraphEditor.TEXT_RANGE_ID);


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help. -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 
Choose one of the following types (you can copy and paste them if you like)

- Bugfix
- Feature
- Code style update (formatting, renaming)
- Refactoring (no functional changes, no API changes)
- Build related changes
- Documentation content changes
- Other (please describe it)

--> 

Test stability

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The `TestGraphEditor.testTokenizeSelectedTextualDS` test occasionally failed because it attempted to select a text fragment before it was added to the view.

Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Added a `NoBackgroundJobsCondition` which makes it easy to wait for all background jobs to finish. When a background task uses the `Job` API, this helper class should allow easy waiting and more stable test.
- Use this condition in the test


## Does this introduce a breaking change?

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

N/A

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->


## Pull request checklist

Please check if your PR fulfills the following requirements:
- [X] Tests for the changes have been added **or** the PR is neither a bug fix nor a feature
- [X] Docs have been reviewed and added / updated if needed **or** the PR is neither a bug fix nor a feature
- [X] The *Unreleased* section in CHANGELOG.md has been amended to reflect the changes in this PR if needed
- [X] Build (`mvn -Pcff verify`) was run locally and any changes were pushed
- [X] The pull request is against the correct branch (`main` for bug fixes, `develop` for new functionality)
- [X] [Dependencies and citation templates](https://github.com/hexatomic/hexatomic/tree/develop/releng/templates) have been updated where necessary **or** there are no new dependencies

---

# Checklist for maintainers

## Releases

- Do **NOT** push the green merge button on GitHub.  
Follow the latest version of the [developer/maintainer docs](https://hexatomic.github.io/hexatomic/dev/) for making releases.
- Check that license and citation information for dependencies are complete (each dependency has a folder in `/THIRD-PARTY/`).
