### PR TITLE
Show more explanations when update check fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Stabilize graph editor test to wait until background jobs are finished before
   selecting the text fragment.
+- Show more explanations when update check fails and only show status message
+  when update check was started in background (#410).
 
 ### Added
 

--- a/bundles/org.corpus_tools.hexatomic.core/src/main/java/org/corpus_tools/hexatomic/core/ApplicationLifecycle.java
+++ b/bundles/org.corpus_tools.hexatomic.core/src/main/java/org/corpus_tools/hexatomic/core/ApplicationLifecycle.java
@@ -28,6 +28,7 @@ import java.net.URL;
 import javax.inject.Inject;
 import org.corpus_tools.hexatomic.core.errors.ErrorService;
 import org.corpus_tools.hexatomic.core.update.AppStartupCompleteEventHandler;
+import org.corpus_tools.hexatomic.core.update.UpdateRunner;
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.Path;
@@ -42,6 +43,7 @@ import org.eclipse.e4.ui.workbench.lifecycle.PostContextCreate;
 import org.eclipse.e4.ui.workbench.lifecycle.ProcessAdditions;
 import org.eclipse.equinox.p2.core.IProvisioningAgent;
 import org.eclipse.osgi.service.datalocation.Location;
+import org.eclipse.swt.widgets.Shell;
 import org.eclipse.wb.swt.ResourceManager;
 import org.eclipse.wb.swt.SwtResourceManager;
 import org.osgi.framework.Bundle;
@@ -105,7 +107,7 @@ public class ApplicationLifecycle {
       UISynchronize sync,
       IProgressMonitor monitor,
       IEventBroker eventBroker,
-      IEclipseContext context) {
+      IEclipseContext context, UpdateRunner updateRunner, Shell shell) {
     
     Runtime.getRuntime().addShutdownHook(new Thread() {
       @Override
@@ -122,12 +124,7 @@ public class ApplicationLifecycle {
     if (!justUpdated && autoUpdateEnabled) {
       //add listener to perform updates as soon as workbench is created
       eventBroker.subscribe(UIEvents.UILifeCycle.APP_STARTUP_COMPLETE, 
-          new AppStartupCompleteEventHandler(eventBroker, 
-            context,
-            agent,
-            sync,
-            monitor,
-              null, eventBroker));
+          new AppStartupCompleteEventHandler(updateRunner, eventBroker, shell));
     } else if (justUpdated) {
       prefs.putBoolean("justUpdated", false);
       try {
@@ -136,13 +133,6 @@ public class ApplicationLifecycle {
         errorService.handleException("Couldn't update preferences", ex, ApplicationLifecycle.class);
       }
     }
-    
-    
   }
-  
-
-  
-  
-
 }
 

--- a/bundles/org.corpus_tools.hexatomic.core/src/main/java/org/corpus_tools/hexatomic/core/ApplicationLifecycle.java
+++ b/bundles/org.corpus_tools.hexatomic.core/src/main/java/org/corpus_tools/hexatomic/core/ApplicationLifecycle.java
@@ -25,7 +25,6 @@ import ch.qos.logback.classic.joran.JoranConfigurator;
 import ch.qos.logback.core.joran.spi.JoranException;
 import java.io.File;
 import java.net.URL;
-import javax.inject.Inject;
 import org.corpus_tools.hexatomic.core.errors.ErrorService;
 import org.corpus_tools.hexatomic.core.update.AppStartupCompleteEventHandler;
 import org.corpus_tools.hexatomic.core.update.UpdateRunner;
@@ -35,7 +34,6 @@ import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.preferences.ConfigurationScope;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
-import org.eclipse.e4.core.contexts.IEclipseContext;
 import org.eclipse.e4.core.services.events.IEventBroker;
 import org.eclipse.e4.ui.di.UISynchronize;
 import org.eclipse.e4.ui.workbench.UIEvents;
@@ -43,7 +41,6 @@ import org.eclipse.e4.ui.workbench.lifecycle.PostContextCreate;
 import org.eclipse.e4.ui.workbench.lifecycle.ProcessAdditions;
 import org.eclipse.equinox.p2.core.IProvisioningAgent;
 import org.eclipse.osgi.service.datalocation.Location;
-import org.eclipse.swt.widgets.Shell;
 import org.eclipse.wb.swt.ResourceManager;
 import org.eclipse.wb.swt.SwtResourceManager;
 import org.osgi.framework.Bundle;
@@ -68,9 +65,7 @@ public class ApplicationLifecycle {
       org.slf4j.LoggerFactory.getLogger(ApplicationLifecycle.class);
   private static final IEclipsePreferences prefs =
       ConfigurationScope.INSTANCE.getNode("org.corpus_tools.hexatomic.core");
-  @Inject
-  ErrorService errorService;
-  
+
   /**
    * Called when the model is loaded and initializes the logging.
    */
@@ -107,7 +102,7 @@ public class ApplicationLifecycle {
       UISynchronize sync,
       IProgressMonitor monitor,
       IEventBroker eventBroker,
-      IEclipseContext context, UpdateRunner updateRunner, Shell shell) {
+      ErrorService errorService, UpdateRunner updateRunner) {
     
     Runtime.getRuntime().addShutdownHook(new Thread() {
       @Override
@@ -123,8 +118,8 @@ public class ApplicationLifecycle {
     boolean autoUpdateEnabled = prefs.getBoolean("autoUpdate", true);
     if (!justUpdated && autoUpdateEnabled) {
       //add listener to perform updates as soon as workbench is created
-      eventBroker.subscribe(UIEvents.UILifeCycle.APP_STARTUP_COMPLETE, 
-          new AppStartupCompleteEventHandler(updateRunner, eventBroker, shell));
+      eventBroker.subscribe(UIEvents.UILifeCycle.APP_STARTUP_COMPLETE,
+          new AppStartupCompleteEventHandler(updateRunner, eventBroker, null));
     } else if (justUpdated) {
       prefs.putBoolean("justUpdated", false);
       try {

--- a/bundles/org.corpus_tools.hexatomic.core/src/main/java/org/corpus_tools/hexatomic/core/handlers/UpdateHandler.java
+++ b/bundles/org.corpus_tools.hexatomic.core/src/main/java/org/corpus_tools/hexatomic/core/handlers/UpdateHandler.java
@@ -21,14 +21,7 @@
 package org.corpus_tools.hexatomic.core.handlers;
 
 import org.corpus_tools.hexatomic.core.update.UpdateRunner;
-import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.e4.core.di.annotations.Execute;
-import org.eclipse.e4.core.services.events.IEventBroker;
-import org.eclipse.e4.ui.di.UISynchronize;
-import org.eclipse.e4.ui.workbench.IWorkbench;
-import org.eclipse.equinox.p2.core.IProvisioningAgent;
 import org.eclipse.swt.widgets.Shell;
 
 public class UpdateHandler {
@@ -36,22 +29,11 @@ public class UpdateHandler {
   /**
    * Execute Update search.
    * 
-   * @param agent OSGi service to create an update operation.
+   * @param updateRunner Service for starting update check jobs.
    * @param shell The user interface shell.
-   * @param sync Helper class to execute code in the UI thread.
-   * @param workbench current workbench to restart the application.
-   * @param events Allows to send events.
    */
   @Execute
-  public void execute(final IProvisioningAgent agent, final Shell shell, final UISynchronize sync,
-      final IWorkbench workbench, IEventBroker events) {
-    Job updateJob = new Job("Update Job") {
-      @Override
-      protected IStatus run(final IProgressMonitor monitor) {
-        UpdateRunner ur = new UpdateRunner();
-        return ur.checkForUpdates(agent, workbench, monitor, shell, sync, events);
-      }
-    };
-    updateJob.schedule();
+  public void execute(UpdateRunner updateRunner, Shell shell) {
+    updateRunner.scheduleUpdateJob(true, shell);
   }
 }

--- a/bundles/org.corpus_tools.hexatomic.core/src/main/java/org/corpus_tools/hexatomic/core/update/UpdateRunner.java
+++ b/bundles/org.corpus_tools.hexatomic.core/src/main/java/org/corpus_tools/hexatomic/core/update/UpdateRunner.java
@@ -107,7 +107,6 @@ public class UpdateRunner {
       events.send(Topics.TOOLBAR_STATUS_MESSAGE, "Hexatomic is up to date");
       return Status.CANCEL_STATUS;
     }
-    log.debug("triggeredManually=" + triggeredManually);
     log.debug("Update status: {} ({})", status.getMessage(), status.getCode());
 
     // create update job
@@ -170,7 +169,7 @@ public class UpdateRunner {
 
     if (triggeredManually) {
       // Give more feedback that needs to be acknowledged
-      final StringBuffer message = new StringBuffer();
+      final StringBuilder message = new StringBuilder();
       message.append("Update check failed for unknown reasons. "
           + "This can happen e.g. if the network is unreachable "
           + "or if some firewalls block the connection to the update server.\n\n"

--- a/bundles/org.corpus_tools.hexatomic.core/src/main/java/org/corpus_tools/hexatomic/core/update/UpdateRunner.java
+++ b/bundles/org.corpus_tools.hexatomic.core/src/main/java/org/corpus_tools/hexatomic/core/update/UpdateRunner.java
@@ -82,7 +82,7 @@ public class UpdateRunner {
     Job updateJob = new Job("Update Job") {
       @Override
       protected IStatus run(final IProgressMonitor monitor) {
-        return checkForUpdates(true, shell);
+        return checkForUpdates(triggeredManually, shell);
       }
     };
     updateJob.schedule();
@@ -107,11 +107,11 @@ public class UpdateRunner {
       events.send(Topics.TOOLBAR_STATUS_MESSAGE, "Hexatomic is up to date");
       return Status.CANCEL_STATUS;
     }
+    log.debug("triggeredManually=" + triggeredManually);
     log.debug("Update status: {} ({})", status.getMessage(), status.getCode());
 
     // create update job
     ProvisioningJob provisioningJob = operation.getProvisioningJob(monitor);
-    log.debug("provisioningJob={}", provisioningJob);
 
     // run update job
     if (provisioningJob != null) {
@@ -128,8 +128,8 @@ public class UpdateRunner {
         return Status.CANCEL_STATUS;
       }
     } else {
-      showProvisioningMessage(triggeredManually);
       log.warn("Couldn't find ProvisioningJob.");
+      showProvisioningErrorMessage(triggeredManually);
       return Status.CANCEL_STATUS;
     }
 
@@ -166,8 +166,7 @@ public class UpdateRunner {
 
 
 
-  private void showProvisioningMessage(boolean triggeredManually) {
-
+  private void showProvisioningErrorMessage(boolean triggeredManually) {
 
     if (triggeredManually) {
       // Give more feedback that needs to be acknowledged

--- a/bundles/org.corpus_tools.hexatomic.core/src/main/java/org/corpus_tools/hexatomic/core/update/UpdateRunner.java
+++ b/bundles/org.corpus_tools.hexatomic.core/src/main/java/org/corpus_tools/hexatomic/core/update/UpdateRunner.java
@@ -29,9 +29,12 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.SubMonitor;
 import org.eclipse.core.runtime.jobs.IJobChangeEvent;
+import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.core.runtime.jobs.JobChangeAdapter;
 import org.eclipse.core.runtime.preferences.ConfigurationScope;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
+import org.eclipse.e4.core.contexts.IEclipseContext;
+import org.eclipse.e4.core.di.annotations.Creatable;
 import org.eclipse.e4.core.services.events.IEventBroker;
 import org.eclipse.e4.ui.di.UISynchronize;
 import org.eclipse.e4.ui.workbench.IWorkbench;
@@ -44,32 +47,63 @@ import org.eclipse.swt.widgets.Shell;
 import org.osgi.service.prefs.BackingStoreException;
 
 
+@Creatable
 public class UpdateRunner {
   private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(UpdateRunner.class);
   private static final IEclipsePreferences prefs =
       ConfigurationScope.INSTANCE.getNode("org.corpus_tools.hexatomic.core");
+
   @Inject
-  ErrorService errorService;
+  private IProvisioningAgent agent;
+
+  @Inject
+  private IEclipseContext context;;
+
+  @Inject
+  private IProgressMonitor monitor;
+
+  @Inject
+  private UISynchronize sync;
+
+  @Inject
+  private IEventBroker events;
+
+  @Inject
+  private ErrorService errorService;
+
+  /**
+   * Schedules a {@link Job} that searches for updates and perform them if wanted.
+   * 
+   * @param triggeredManually Indicates whether the update processes was started by a manual action
+   *        of the user.
+   * @param shell The user interface shell.
+   */
+  public void scheduleUpdateJob(boolean triggeredManually, Shell shell) {
+    Job updateJob = new Job("Update Job") {
+      @Override
+      protected IStatus run(final IProgressMonitor monitor) {
+        return checkForUpdates(true, shell);
+      }
+    };
+    updateJob.schedule();
+  }
+
 
   /**
    * Search for updates and perform them if wanted.
    * 
-   * @param agent OSGi service to create an update operation.
-   * @param workbench current workbench to restart the application.
-   * @param monitor interface to show progress of update operation.
+   * @param triggeredManually Indicates whether the update processes was started by a manual action
+   *        of the user.
    * @param shell The user interface shell.
-   * @param sync Helper class to execute code in the UI thread.
-   * @param events Allows to send events.
-   * 
    */
-  public IStatus checkForUpdates(final IProvisioningAgent agent, final IWorkbench workbench,
-      IProgressMonitor monitor, final Shell shell, final UISynchronize sync, IEventBroker events) {
+  private IStatus checkForUpdates(boolean triggeredManually, Shell shell) {
+
     final UpdateOperation operation = createUpdateOperation(agent);
     log.debug("Update operation created");
     // Check if there are Updates available
     SubMonitor sub = SubMonitor.convert(monitor, "Checking for application updates...", 200);
     final IStatus status = operation.resolveModal(sub.newChild(100));
-    if (status.getCode() == UpdateOperation.STATUS_NOTHING_TO_UPDATE) {
+    if (false && status.getCode() == UpdateOperation.STATUS_NOTHING_TO_UPDATE) {
       events.send(Topics.TOOLBAR_STATUS_MESSAGE, "Hexatomic is up to date");
       return Status.CANCEL_STATUS;
     }
@@ -86,6 +120,7 @@ public class UpdateRunner {
       sync.syncExec(() -> performUpdate.set(MessageDialog.openQuestion(shell, "Update available",
           "Do you want to install the available update?")));
       if (performUpdate.get()) {
+        IWorkbench workbench = context.get(IWorkbench.class);
         configureProvisioningJob(provisioningJob, shell, sync, workbench);
         provisioningJob.schedule();
         return Status.OK_STATUS;
@@ -93,7 +128,7 @@ public class UpdateRunner {
         return Status.CANCEL_STATUS;
       }
     } else {
-      showProvisioningMessage(shell, sync);
+      showProvisioningMessage(triggeredManually);
       log.warn("Couldn't find ProvisioningJob.");
       return Status.CANCEL_STATUS;
     }
@@ -131,9 +166,35 @@ public class UpdateRunner {
 
 
 
-  private void showProvisioningMessage(final Shell parent, final UISynchronize sync) {
-    sync.syncExec(() -> MessageDialog.openWarning(parent, "Couldn't find ProvisioningJob",
-        "Did you start Update from within the Eclipse IDE?"));
+  private void showProvisioningMessage(boolean triggeredManually) {
+
+
+    if (triggeredManually) {
+      // Give more feedback that needs to be acknowledged
+      final StringBuffer message = new StringBuffer();
+      message.append("Update check failed for unknown reasons. "
+          + "This can happen e.g. if the network is unreachable "
+          + "or if some firewalls block the connection to the update server.\n\n"
+          + "Please retry later or check the debug logs if the problem persists.");
+
+      // Check if a special environment variable set in the Eclipse run configuration is set
+      if ("true".equalsIgnoreCase(System.getenv("runInEclipse"))) {
+        // Hexatomic is started/debugged from inside Eclipse and the developer might need some
+        // additional hints that
+        // starting the update from Eclipse itself won't work.
+        message.append("\n\n");
+        message.append(
+            "In case of a developer build, this error can also occur when you start Hexatomic from inside the Eclipse development environment.");
+      }
+      
+      errorService.showError("Update check failed", message.toString(), UpdateRunner.class);
+
+    } else {
+      // Since this was a background task, also inform about this less prominent
+      events.send(Topics.TOOLBAR_STATUS_MESSAGE, "Update check failed.");
+    }
+
+
   }
 
   static UpdateOperation createUpdateOperation(IProvisioningAgent agent) {

--- a/bundles/org.corpus_tools.hexatomic.core/src/main/java/org/corpus_tools/hexatomic/core/update/UpdateRunner.java
+++ b/bundles/org.corpus_tools.hexatomic.core/src/main/java/org/corpus_tools/hexatomic/core/update/UpdateRunner.java
@@ -57,7 +57,7 @@ public class UpdateRunner {
   private IProvisioningAgent agent;
 
   @Inject
-  private IEclipseContext context;;
+  private IEclipseContext context;
 
   @Inject
   private IProgressMonitor monitor;
@@ -103,7 +103,7 @@ public class UpdateRunner {
     // Check if there are Updates available
     SubMonitor sub = SubMonitor.convert(monitor, "Checking for application updates...", 200);
     final IStatus status = operation.resolveModal(sub.newChild(100));
-    if (false && status.getCode() == UpdateOperation.STATUS_NOTHING_TO_UPDATE) {
+    if (status.getCode() == UpdateOperation.STATUS_NOTHING_TO_UPDATE) {
       events.send(Topics.TOOLBAR_STATUS_MESSAGE, "Hexatomic is up to date");
       return Status.CANCEL_STATUS;
     }
@@ -184,7 +184,9 @@ public class UpdateRunner {
         // starting the update from Eclipse itself won't work.
         message.append("\n\n");
         message.append(
-            "In case of a developer build, this error can also occur when you start Hexatomic from inside the Eclipse development environment.");
+            "In case of a developer build, "
+                + "this error can also occur when you start Hexatomic "
+                + "from inside the Eclipse development environment.");
       }
       
       errorService.showError("Update check failed", message.toString(), UpdateRunner.class);

--- a/releng/ide/org.corpus_tools.hexatomic.product.launch
+++ b/releng/ide/org.corpus_tools.hexatomic.product.launch
@@ -25,6 +25,10 @@
     <booleanAttribute key="generateProfile" value="true"/>
     <booleanAttribute key="includeOptional" value="true"/>
     <stringAttribute key="location" value="${workspace_loc}/../runtime-org.corpus_tools.hexatomic.product"/>
+    <booleanAttribute key="org.eclipse.debug.core.ATTR_FORCE_SYSTEM_CONSOLE_ENCODING" value="false"/>
+    <mapAttribute key="org.eclipse.debug.core.environmentVariables">
+        <mapEntry key="runInEclipse" value="true"/>
+    </mapAttribute>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_ATTR_USE_ARGFILE" value="false"/>
     <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
     <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consoleLog -clearPersistedState -lifeCycleURI bundleclass://org.corpus_tools.hexatomic.core/org.corpus_tools.hexatomic.core.ApplicationLifecycle"/>


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help. -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 
Choose one of the following types (you can copy and paste them if you like)

- Bugfix
- Feature
- Code style update (formatting, renaming)
- Refactoring (no functional changes, no API changes)
- Build related changes
- Documentation content changes
- Other (please describe it)

--> 

Refactoring (same feature, but better messaging)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

There are ways the update check can fail, that the logic assumes that there might be an update available (the status code from the RCP `UpdateOperation` is not `STATUS_NOTHING_TO_UPDATE`, but get the `ProvisioningJob` still fails.

Currently, a message is shown that is clearly targeted at developers, reminding them that they should not start the update from a Eclipse debug run. But the issue can be triggered by other means and is shown to probably confused users.

Issue Number: closes #410

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

-  Limits the information a user needs to see. For background update checks, only a status message is shown. For manual checks, a dialog (with error log!) is shown.
- The error dialog is targeted at end users, and explains what happened and what might have caused it (e.g. network/firewall issues)
- In case Hexatomic was run using the Eclipse run configuration (and only then) the message is altered to also add instructions to developers of Hexatomic.
- The code has been refactored to remove some duplicated code

## Does this introduce a breaking change?

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

N/A

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

The manual regression tests <https://hexatomic.github.io/hexatomic/dev/v1.0/maintenance/contributions/index.html#manual-regression-tests> have been executed successfully.

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added **or** the PR is neither a bug fix nor a feature
- [x] Docs have been reviewed and added / updated if needed **or** the PR is neither a bug fix nor a feature
- [x] The *Unreleased* section in CHANGELOG.md has been amended to reflect the changes in this PR if needed
- [x] Build (`mvn -Pcff verify`) was run locally and any changes were pushed
- [x] The pull request is against the correct branch (`main` for bug fixes, `develop` for new functionality)
- [x] [Dependencies and citation templates](https://github.com/hexatomic/hexatomic/tree/develop/releng/templates) have been updated where necessary **or** there are no new dependencies

---

# Checklist for maintainers

## Releases

- Do **NOT** push the green merge button on GitHub.  
Follow the latest version of the [developer/maintainer docs](https://hexatomic.github.io/hexatomic/dev/) for making releases.
- Check that license and citation information for dependencies are complete (each dependency has a folder in `/THIRD-PARTY/`).
