### PR TITLE
Fix #420 by removing unnecessary layout data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- "Tokenize after import" checkbox label was located wrong in text importer (#420)
 - Running the tests on macOS would fail (#417). An GitHub action is now
   configured to execute the tests also on macOS for each pull request.
 - About dialog did mention the Apache License for Hexatomic itself, but not the

--- a/bundles/org.corpus_tools.hexatomic.formats/src/main/java/org/corpus_tools/hexatomic/formats/txt/TxtImportConfiguration.java
+++ b/bundles/org.corpus_tools.hexatomic.formats/src/main/java/org/corpus_tools/hexatomic/formats/txt/TxtImportConfiguration.java
@@ -25,7 +25,6 @@ import org.corpus_tools.hexatomic.formats.ConfigurationPage;
 import org.corpus_tools.hexatomic.formats.importer.ImportFormat;
 import org.corpus_tools.pepper.modules.coreModules.TextImporter;
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
@@ -59,7 +58,6 @@ public class TxtImportConfiguration extends ConfigurationPage {
     btnTokenize = new Button(container, SWT.CHECK);
     btnTokenize.setText("Tokenize after import");
     btnTokenize.setSelection(true);
-    btnTokenize.setLayoutData(new GridData(SWT.FILL, SWT.FILL, false, true, 1, 1));
   }
 
   @Override


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help. -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 
Choose one of the following types (you can copy and paste them if you like)

- Bugfix
- Feature
- Code style update (formatting, renaming)
- Refactoring (no functional changes, no API changes)
- Build related changes
- Documentation content changes
- Other (please describe it)

--> 

Bugfix

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The layout for the text importer setting was broken, the checkbox was not aligned with its label.

Issue Number: fixes #420 


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- The text importer settings dialog now uses the default grid data layout settings

## Does this introduce a breaking change?

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

N/A

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->


## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added **or** the PR is neither a bug fix nor a feature
- [x] Docs have been reviewed and added / updated if needed **or** the PR is neither a bug fix nor a feature
- [x] The *Unreleased* section in CHANGELOG.md has been amended to reflect the changes in this PR if needed
- [x] Build (`mvn -Pcff verify`) was run locally and any changes were pushed
- [x] The pull request is against the correct branch (`main` for bug fixes, `develop` for new functionality)
- [x] [Dependencies and citation templates](https://github.com/hexatomic/hexatomic/tree/develop/releng/templates) have been updated where necessary **or** there are no new dependencies

---

# Checklist for maintainers

## Releases

- Do **NOT** push the green merge button on GitHub.  
Follow the latest version of the [developer/maintainer docs](https://hexatomic.github.io/hexatomic/dev/) for making releases.
- Check that license and citation information for dependencies are complete (each dependency has a folder in `/THIRD-PARTY/`).
