### PR TITLE
Insert node names in graph editor console on double click and remember opened project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added HOW-TO for importing and annotating a demo corpus to the user
   documentation (#446).
+- Double-click on nodes in the graph viewer will add the node name reference to
+  the command prompt.
+- Hexatomic will now remember the last opened project location and pre-select it
+  in the "Open Salt Project" dialog.
 
 ### Fixed
 

--- a/bundles/org.corpus_tools.hexatomic.core/src/main/java/org/corpus_tools/hexatomic/core/Preferences.java
+++ b/bundles/org.corpus_tools.hexatomic.core/src/main/java/org/corpus_tools/hexatomic/core/Preferences.java
@@ -35,9 +35,10 @@ public final class Preferences {
   /** Whether to automatically check for updates. **/
   public static final String AUTO_UPDATE = "autoUpdate";
 
-  /** Set temporarly after an update was applied, so we know not check for newer updates. */
+  /** Set temporarily after an update was applied, so we know not check for newer updates. */
   public static final String JUST_UPDATED = "justUpdated";
 
-
+  /** Location of the last opened project. */
+  public static final String LAST_PROJECT_LOCATION = "lastProjectLocation";
 
 }

--- a/bundles/org.corpus_tools.hexatomic.graph/src/main/java/org/corpus_tools/hexatomic/console/ConsoleView.java
+++ b/bundles/org.corpus_tools.hexatomic.graph/src/main/java/org/corpus_tools/hexatomic/console/ConsoleView.java
@@ -27,6 +27,7 @@ import java.util.Optional;
 import org.corpus_tools.hexatomic.core.ProjectManager;
 import org.corpus_tools.salt.common.SDocumentGraph;
 import org.corpus_tools.salt.common.STextualDS;
+import org.corpus_tools.salt.core.SNode;
 import org.eclipse.e4.ui.di.UISynchronize;
 import org.eclipse.jface.resource.JFaceResources;
 import org.eclipse.jface.text.BadLocationException;
@@ -122,10 +123,29 @@ public class ConsoleView implements Runnable, IDocumentListener, VerifyListener 
   public void writeLine(String str) {
     sync.asyncExec(() -> {
       document.set(document.get() + str + "\n");
-      if (view != null && view.getTextWidget() != null) {
-        view.getTextWidget().setCaretOffset(document.getLength());
-        view.getTextWidget().setTopIndex(view.getTextWidget().getLineCount() - 1);
-      }
+      synchronizeViewWithDocument();
+    });
+  }
+
+  private void synchronizeViewWithDocument() {
+    if (view != null && view.getTextWidget() != null) {
+      view.getTextWidget().setCaretOffset(document.getLength());
+      view.getTextWidget().setTopIndex(view.getTextWidget().getLineCount() - 1);
+    }
+  }
+
+  /**
+   * Allows to append the name of the given node to the prompt, e.g. because it was selected in the
+   * graph view.
+   * 
+   * @param n The node that was selected.
+   */
+  public void appendNodeName(SNode n) {
+    sync.asyncExec(() -> {
+      String prefix = document.get().endsWith(" ") ? "#" : " #";
+      document.set(document.get() + prefix + n.getName() + " ");
+      synchronizeViewWithDocument();
+      view.getTextWidget().setFocus();
     });
   }
 

--- a/bundles/org.corpus_tools.hexatomic.graph/src/main/java/org/corpus_tools/hexatomic/graph/GraphEditor.java
+++ b/bundles/org.corpus_tools.hexatomic.graph/src/main/java/org/corpus_tools/hexatomic/graph/GraphEditor.java
@@ -83,6 +83,7 @@ import org.eclipse.jface.layout.RowDataFactory;
 import org.eclipse.jface.layout.RowLayoutFactory;
 import org.eclipse.jface.text.Document;
 import org.eclipse.jface.text.source.SourceViewer;
+import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.viewers.Viewer;
 import org.eclipse.jface.viewers.ViewerFilter;
 import org.eclipse.swt.SWT;
@@ -749,6 +750,12 @@ public class GraphEditor {
     @Override
     public void mouseDoubleClick(MouseEvent e) {
       Point clickedInViewport = new Point(e.x, e.y);
+      if (viewer.getSelection() instanceof IStructuredSelection) {
+        IStructuredSelection selection = (IStructuredSelection) viewer.getSelection();
+        if (selection.getFirstElement() instanceof SNode) {
+          consoleView.appendNodeName((SNode) selection.getFirstElement());
+        }
+      }
       centerViewportToPoint(clickedInViewport);
     }
   }

--- a/bundles/org.corpus_tools.hexatomic.graph/src/main/java/org/corpus_tools/hexatomic/graph/GraphEditor.java
+++ b/bundles/org.corpus_tools.hexatomic.graph/src/main/java/org/corpus_tools/hexatomic/graph/GraphEditor.java
@@ -168,6 +168,10 @@ public class GraphEditor {
 
   private GraphViewer viewer;
 
+  public GraphViewer getViewer() {
+    return viewer;
+  }
+
   @Inject
   UISynchronize sync;
 
@@ -200,6 +204,7 @@ public class GraphEditor {
     }
     return null;
   }
+
 
   /**
    * Create a new graph viewer.
@@ -750,13 +755,20 @@ public class GraphEditor {
     @Override
     public void mouseDoubleClick(MouseEvent e) {
       Point clickedInViewport = new Point(e.x, e.y);
-      if (viewer.getSelection() instanceof IStructuredSelection) {
-        IStructuredSelection selection = (IStructuredSelection) viewer.getSelection();
-        if (selection.getFirstElement() instanceof SNode) {
-          consoleView.appendNodeName((SNode) selection.getFirstElement());
-        }
-      }
+      appendSelectedNodeNameToConsole();
       centerViewportToPoint(clickedInViewport);
+    }
+  }
+
+  /**
+   * Helper function which appends the name of the currently selected node to the internal console.
+   */
+  public void appendSelectedNodeNameToConsole() {
+    if (viewer.getSelection() instanceof IStructuredSelection) {
+      IStructuredSelection selection = (IStructuredSelection) viewer.getSelection();
+      if (selection.getFirstElement() instanceof SNode) {
+        consoleView.appendNodeName((SNode) selection.getFirstElement());
+      }
     }
   }
 

--- a/docs/user/src/howtos/example-import.md
+++ b/docs/user/src/howtos/example-import.md
@@ -20,6 +20,6 @@ Then type `cat` into the “Search” field and click on the `tiger::cat` filter
 This still shows the whole document, but now we can select the segments we are interested in.
 Click on the first three segments while holding the <kbd>Ctrl</kbd> key.
 ![Graph editor with selected segments](pcc2-select-segments.png)
-1. Add new annotations using the [console](../usage/graph-editor/console.md). To add a root node connecting the trailing token “!” with the sentence constituent node, enter `n tiger:cat:ROOT  #tok_7 #const_2` to the console and press <kbd>Enter</kbd>. Note that the segmentation changes because we connected the previously separate segments.   
+9. Add new annotations using the [console](../usage/graph-editor/console.md). To add a root node connecting the trailing token “!” with the sentence constituent node, enter `n tiger:cat:ROOT` in the console. Then double-click on the `tok_7` node and again on the  `const_2` node. This should complete the prompt in the console to `n tiger:cat:ROOT #tok_7 #const_2`. With the cursor active at the end of the prompt, press <kbd>Enter</kbd>. Note that the segmentation changes because we connected the previously separate segments.   
 ![Adding a root node with the graph editor](pcc2-add-root-node.png)
-2. Save the project via by clicking on the *File* menu and then *Save Salt Project As...* to persist the changes as a [project](../usage/projects.md).
+10. Save the project via by clicking on the *File* menu and then *Save Salt Project As...* to persist the changes as a [project](../usage/projects.md).

--- a/docs/user/src/usage/graph-editor/README.md
+++ b/docs/user/src/usage/graph-editor/README.md
@@ -37,5 +37,7 @@ You can navigate the graph view as follows:
 
 - You can **center the view** around a specific point in the graph by double-clicking that point.
 
+- Double-clicking over a node will additionally **append the node name reference to the console prompt**. This allows to insert node references easily without having to type them in [console commands](console.md).
+
 If you don't like the layout of the graph, you can change it by dragging nodes with your mouse or [adjusting the layout parameters](./layout-params.md).
 

--- a/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/graph/NoBackgroundJobsCondition.java
+++ b/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/graph/NoBackgroundJobsCondition.java
@@ -1,4 +1,4 @@
-package org.corpus_tools.hexatomic.it.tests;
+package org.corpus_tools.hexatomic.graph;
 
 import org.corpus_tools.hexatomic.core.UiStatusReport;
 import org.eclipse.swtbot.swt.finder.waits.DefaultCondition;

--- a/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/graph/TestGraphEditor.java
+++ b/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/graph/TestGraphEditor.java
@@ -3,7 +3,6 @@ package org.corpus_tools.hexatomic.graph;
 import static org.eclipse.swtbot.swt.finder.matchers.WidgetMatcherFactory.widgetOfType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -625,7 +624,18 @@ class TestGraphEditor {
       assertEquals(0, graph.getRelations(STRUCTURE3_ID, STRUCTURE5_ID).size());
 
       SWTBotView view = bot.partByTitle(DOC1_TITLE);
-      assertInstanceOf(GraphEditor.class, view.getPart().getObject());
+      bot.waitUntil(new DefaultCondition() {
+
+        @Override
+        public boolean test() throws Exception {
+          return view.getPart().getObject() instanceof GraphEditor;
+        }
+
+        @Override
+        public String getFailureMessage() {
+          return "Part object did not have the GraphEditor type";
+        }
+      });
       GraphEditor graphEditor = (GraphEditor) view.getPart().getObject();
 
       // Test that double clicking without selected node does nothing

--- a/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/graph/TestGraphEditor.java
+++ b/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/graph/TestGraphEditor.java
@@ -624,6 +624,7 @@ class TestGraphEditor {
       assertEquals(0, graph.getRelations(STRUCTURE3_ID, STRUCTURE5_ID).size());
 
       SWTBotView view = bot.partByTitle(DOC1_TITLE);
+      view.show();
       bot.waitUntil(new DefaultCondition() {
 
         @Override

--- a/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/graph/ViewLocationReachedCondition.java
+++ b/tests/org.corpus_tools.hexatomic.it.tests/src/main/java/org/corpus_tools/hexatomic/graph/ViewLocationReachedCondition.java
@@ -1,4 +1,4 @@
-package org.corpus_tools.hexatomic.it.tests;
+package org.corpus_tools.hexatomic.graph;
 
 import org.eclipse.draw2d.Viewport;
 import org.eclipse.draw2d.geometry.Point;


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help. -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 
Choose one of the following types (you can copy and paste them if you like)

- Bugfix
- Feature
- Code style update (formatting, renaming)
- Refactoring (no functional changes, no API changes)
- Build related changes
- Documentation content changes
- Other (please describe it)

--> 

Feature

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The user always has to type the full node name in the graph editor console when referencing it.

Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- When double clicking in the graph viewer above a node, the node name reference (e.g. `#n2`) will be appended to the console prompt
- The last loaded project location is stored as preference, so it is remembered when Hexatomic is restarted

## Does this introduce a breaking change?

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

N/A

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->


## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added **or** the PR is neither a bug fix nor a feature
- [x] Docs have been reviewed and added / updated if needed **or** the PR is neither a bug fix nor a feature
- [x] The *Unreleased* section in CHANGELOG.md has been amended to reflect the changes in this PR if needed
- [ ] Build (`mvn -Pcff verify`) was run locally and any changes were pushed
- [x] The pull request is against the correct branch (`main` for bug fixes, `develop` for new functionality)
- [x] [Dependencies and citation templates](https://github.com/hexatomic/hexatomic/tree/develop/releng/templates) have been updated where necessary **or** there are no new dependencies

---

# Checklist for maintainers

## Releases

- Do **NOT** push the green merge button on GitHub.  
Follow the latest version of the [developer/maintainer docs](https://hexatomic.github.io/hexatomic/dev/) for making releases.
- Check that license and citation information for dependencies are complete (each dependency has a folder in `/THIRD-PARTY/`).
