### PR TITLE
Prepare releases to use P2 repo on GitHub pages with Git LFS enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Updated the included Java Runtime Environment to 17.0.7.
+- Use GitHub raw URL as P2 update site to fix issues with larger files.
 
 ## [1.4.2] - 2023-03-28
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -35,7 +35,7 @@ identifiers:
   value: 10.5281/zenodo.6900689
 doi: 10.5281/zenodo.6900689
 version: 1.5.0-SNAPSHOT
-date-released: 2023-07-21
+date-released: 2023-09-11
 references:
 - type: art
   title: Font Awesome

--- a/docs/dev/src/maintenance/contributions/manual-update-tests.md
+++ b/docs/dev/src/maintenance/contributions/manual-update-tests.md
@@ -1,7 +1,7 @@
 # Manual tests of updates
 
 For updates, we rely on the Eclipse platform and our update site that is [hosted
-on GitHub pages](https://github.com/hexatomic/updates) and there are several
+on GitHub](https://github.com/hexatomic/updates) and there are several
 things that can't be tested automatically, but can break for various reasons.
 We have to test two scenarios: 
 - Updates from the last released version works with the changes from this pull request

--- a/releng/org.corpus_tools.hexatomic.product/org.corpus_tools.hexatomic.p2.inf
+++ b/releng/org.corpus_tools.hexatomic.product/org.corpus_tools.hexatomic.p2.inf
@@ -1,3 +1,3 @@
   instructions.configure=\
-  addRepository(type:0,location:https${#58}//hexatomic.github.io/updates/v1/repository/,name:Hexatomic Update Site,enabled:true);\
-  addRepository(type:1,location:https${#58}//hexatomic.github.io/updates/v1/repository/,name:Hexatomic Update Site,enabled:true);\
+  addRepository(type:0,location:https${#58}//raw.githubusercontent.com/hexatomic/updates/main/v1/repository/,name:Hexatomic Update Site,enabled:true);\
+  addRepository(type:1,location:https${#58}//raw.githubusercontent.com/hexatomic/updates/main/v1/repository/,name:Hexatomic Update Site,enabled:true);\

--- a/releng/org.corpus_tools.hexatomic.target/org.corpus_tools.hexatomic.target.target
+++ b/releng/org.corpus_tools.hexatomic.target/org.corpus_tools.hexatomic.target.target
@@ -3,7 +3,7 @@
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl --><target name="Hexatomic Target Platform Definition" sequenceNumber="1677614120">
   <locations>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-      <repository location="https://download.eclipse.org/justj/jres/17/updates/release/latest"/>
+      <repository location="https://download.eclipse.org/justj/jres/17/updates/release/17.0.7"/>
 	    <unit id="org.eclipse.justj.openjdk.hotspot.jre.full.stripped.feature.group" version="17.0.7.v20230425-1502"/>
     </location>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help. -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 
Choose one of the following types (you can copy and paste them if you like)

- Bugfix
- Feature
- Code style update (formatting, renaming)
- Refactoring (no functional changes, no API changes)
- Build related changes
- Documentation content changes
- Other (please describe it)

--> 

Build related changes

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

 When the build artifacts become too large (like including an unstripped JDK in the product), we can't upload the large files to GitHub pages anymore when releasing Hexatomic
If we enable Git LFS on the update site, artifacts queried using the current P2 URL because GitHub pages does not support LFS (https://docs.github.com/en/repositories/working-with-files/managing-large-files/about-git-large-file-storage) and the update will fail.


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Use raw URLs to the assets in the GitHub repo instead of the GitHub pages URLs (e.g. https://raw.githubusercontent.com/octocat/Hello-World/master/README)

## Does this introduce a breaking change?

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

N/A

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->


## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added **or** the PR is neither a bug fix nor a feature
- [x] Docs have been reviewed and added / updated if needed **or** the PR is neither a bug fix nor a feature
- [x] The *Unreleased* section in CHANGELOG.md has been amended to reflect the changes in this PR if needed
- [x] Build (`mvn -Pcff verify`) was run locally and any changes were pushed
- [x] The pull request is against the correct branch (`main` for bug fixes, `develop` for new functionality)
- [x] [Dependencies and citation templates](https://github.com/hexatomic/hexatomic/tree/develop/releng/templates) have been updated where necessary **or** there are no new dependencies

---

# Checklist for maintainers

## Releases

- Do **NOT** push the green merge button on GitHub.  
Follow the latest version of the [developer/maintainer docs](https://hexatomic.github.io/hexatomic/dev/) for making releases.
- Check that license and citation information for dependencies are complete (each dependency has a folder in `/THIRD-PARTY/`).
